### PR TITLE
ci: Fix tarpaulin failing on full test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -117,7 +117,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: 0.21.0
-          args: "--skip-clean --release --timeout=180 -- --include-ignored"
+          args: "--skip-clean --release --timeout=180 --engine=llvm -- --include-ignored"
         if: ${{ matrix.label == 'full' }}
 
       - name: Codecov submission of fast test results


### PR DESCRIPTION
Adding `--engine=llvm` is necessary to let tarpaulin run.