### PR TITLE
feat: refactor annotate seqvars cli

### DIFF
--- a/src/annotate/seqvars/csq.rs
+++ b/src/annotate/seqvars/csq.rs
@@ -1117,7 +1117,7 @@ mod test {
             tx_db,
             Assembly::Grch37p10,
             MehariProviderConfigBuilder::default()
-                .transcript_picking(vec![
+                .pick_transcript(vec![
                     TranscriptPickType::ManePlusClinical,
                     TranscriptPickType::ManeSelect,
                     TranscriptPickType::Length,
@@ -1222,7 +1222,7 @@ mod test {
             tx_db,
             Assembly::Grch37p10,
             MehariProviderConfigBuilder::default()
-                .transcript_picking(vec![
+                .pick_transcript(vec![
                     TranscriptPickType::ManePlusClinical,
                     TranscriptPickType::ManeSelect,
                     TranscriptPickType::Length,
@@ -1282,7 +1282,7 @@ mod test {
             tx_db,
             Assembly::Grch37p10,
             MehariProviderConfigBuilder::default()
-                .transcript_picking(vec![
+                .pick_transcript(vec![
                     TranscriptPickType::ManePlusClinical,
                     TranscriptPickType::ManeSelect,
                     TranscriptPickType::Length,
@@ -1350,7 +1350,7 @@ mod test {
             tx_db,
             Assembly::Grch37p10,
             MehariProviderConfigBuilder::default()
-                .transcript_picking(picks)
+                .pick_transcript(picks)
                 .build()
                 .unwrap(),
         ));
@@ -1417,7 +1417,7 @@ mod test {
             tx_db,
             Assembly::Grch37p10,
             MehariProviderConfigBuilder::default()
-                .transcript_picking(picks)
+                .pick_transcript(picks)
                 .build()
                 .unwrap(),
         ));

--- a/src/annotate/seqvars/csq.rs
+++ b/src/annotate/seqvars/csq.rs
@@ -65,7 +65,7 @@ pub struct Config {
 
     /// Whether to report only the worst consequence for each picked transcript.
     #[builder(default = "false")]
-    pub report_worst_consequence_only: bool,
+    pub report_most_severe_consequence_only: bool,
 
     /// Whether to discard intergenic variants.
     #[builder(default = "true")]
@@ -282,7 +282,7 @@ impl ConsequencePredictor {
         };
 
         // Short-circuit if to report all transcript results.
-        if !self.config.report_worst_consequence_only {
+        if !self.config.report_most_severe_consequence_only {
             return ann_fields;
         }
 
@@ -1130,7 +1130,7 @@ mod test {
             provider,
             Assembly::Grch37p10,
             ConsequencePredictorConfigBuilder::default()
-                .report_worst_consequence_only(true)
+                .report_most_severe_consequence_only(true)
                 .build()?,
         );
 
@@ -1324,13 +1324,13 @@ mod test {
     fn annotate_snv_brca1_transcript_picking_reporting(
         #[case] spdi: &str,
         #[case] pick_transcripts: bool,
-        #[case] report_worst_consequence_only: bool,
+        #[case] report_most_severe_consequence_only: bool,
     ) -> Result<(), anyhow::Error> {
         crate::common::set_snapshot_suffix!(
             "{}-{}-{}",
             spdi.replace(':', "-"),
             pick_transcripts,
-            !report_worst_consequence_only
+            !report_most_severe_consequence_only
         );
 
         let spdi = spdi.split(':').map(|s| s.to_string()).collect::<Vec<_>>();
@@ -1359,7 +1359,7 @@ mod test {
             provider,
             Assembly::Grch37p10,
             ConfigBuilder::default()
-                .report_worst_consequence_only(report_worst_consequence_only)
+                .report_most_severe_consequence_only(report_most_severe_consequence_only)
                 .build()
                 .unwrap(),
         );
@@ -1389,13 +1389,13 @@ mod test {
     fn annotate_snv_ttn_transcript_picking_reporting(
         #[case] spdi: &str,
         #[case] pick_transcripts: bool,
-        #[case] report_worst_consequence_only: bool,
+        #[case] report_most_severe_consequence_only: bool,
     ) -> Result<(), anyhow::Error> {
         crate::common::set_snapshot_suffix!(
             "{}-{}-{}",
             spdi.replace(':', "-"),
             pick_transcripts,
-            !report_worst_consequence_only
+            !report_most_severe_consequence_only
         );
 
         let spdi = spdi.split(':').map(|s| s.to_string()).collect::<Vec<_>>();
@@ -1426,7 +1426,7 @@ mod test {
             provider,
             Assembly::Grch37p10,
             ConfigBuilder::default()
-                .report_worst_consequence_only(report_worst_consequence_only)
+                .report_most_severe_consequence_only(report_most_severe_consequence_only)
                 .build()
                 .unwrap(),
         );
@@ -1478,7 +1478,7 @@ mod test {
 
     fn annotate_opa1_vars(
         path_tsv: &str,
-        report_worst_consequence_only: bool,
+        report_most_severe_consequence_only: bool,
     ) -> Result<(), anyhow::Error> {
         let txs = vec![
             String::from("NM_001354663.2"),
@@ -1489,7 +1489,7 @@ mod test {
             String::from("NM_130837.3"),
         ];
 
-        annotate_vars(path_tsv, &txs, report_worst_consequence_only)
+        annotate_vars(path_tsv, &txs, report_most_severe_consequence_only)
     }
 
     // Compare to SnpEff annotated variants for BRCA1, touching special cases.
@@ -1518,7 +1518,7 @@ mod test {
 
     fn annotate_brca1_vars(
         path_tsv: &str,
-        report_worst_consequence_only: bool,
+        report_most_severe_consequence_only: bool,
     ) -> Result<(), anyhow::Error> {
         let txs = vec![
             String::from("NM_007294.4"),
@@ -1528,13 +1528,13 @@ mod test {
             String::from("NM_007300.4"),
         ];
 
-        annotate_vars(path_tsv, &txs, report_worst_consequence_only)
+        annotate_vars(path_tsv, &txs, report_most_severe_consequence_only)
     }
 
     fn annotate_vars(
         path_tsv: &str,
         txs: &[String],
-        report_worst_consequence_only: bool,
+        report_most_severe_consequence_only: bool,
     ) -> Result<(), anyhow::Error> {
         let tx_path = "tests/data/annotate/db/grch37/txs.bin.zst";
         let tx_db = load_tx_db(tx_path)?;
@@ -1547,7 +1547,7 @@ mod test {
             provider,
             Assembly::Grch37p10,
             ConfigBuilder::default()
-                .report_worst_consequence_only(report_worst_consequence_only)
+                .report_most_severe_consequence_only(report_most_severe_consequence_only)
                 .build()
                 .unwrap(),
         );

--- a/src/annotate/seqvars/csq.rs
+++ b/src/annotate/seqvars/csq.rs
@@ -1282,7 +1282,11 @@ mod test {
             tx_db,
             Assembly::Grch37p10,
             MehariProviderConfigBuilder::default()
-                .transcript_picking(true)
+                .transcript_picking(vec![
+                    TranscriptPickType::ManePlusClinical,
+                    TranscriptPickType::ManeSelect,
+                    TranscriptPickType::Length,
+                ])
                 .build()?,
         ));
 

--- a/src/annotate/seqvars/csq.rs
+++ b/src/annotate/seqvars/csq.rs
@@ -63,7 +63,7 @@ pub struct Config {
     #[builder(default = "TranscriptSource::Both")]
     pub transcript_source: TranscriptSource,
 
-    /// Whether to report consequences for all picked transcripts.
+    /// Whether to report only the worst consequence for each picked transcript.
     #[builder(default = "false")]
     pub report_worst_consequence_only: bool,
 

--- a/src/annotate/seqvars/mod.rs
+++ b/src/annotate/seqvars/mod.rs
@@ -1370,6 +1370,7 @@ impl AsyncAnnotatedVariantWriter for VarFishSeqvarTsvWriter {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 enum AnnotatorEnum {
     Frequency(FrequencyAnnotator),
     Clinvar(ClinvarAnnotator),

--- a/src/annotate/seqvars/mod.rs
+++ b/src/annotate/seqvars/mod.rs
@@ -95,8 +95,8 @@ pub struct Args {
     pub transcript_source: csq::TranscriptSource,
 
     /// Whether to report only the worst consequence for each picked transcript.
-    #[arg(long, default_value_t = false)]
-    pub report_most_severe_consequence_only: bool,
+    #[arg(long)]
+    pub report_most_severe_consequence_by: Option<ConsequenceBy>,
 
     /// Which kind of transcript to pick / restrict to. Default is not to pick at all.
     ///
@@ -123,6 +123,26 @@ pub struct Args {
     /// What to annotate and which source to use.
     #[command(flatten)]
     pub sources: Sources,
+}
+
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Display,
+    clap::ValueEnum,
+    VariantArray,
+    parse_display::FromStr,
+)]
+pub enum ConsequenceBy {
+    Gene,
+    Transcript,
+    // or "Variant"?
+    Allele,
 }
 
 #[derive(
@@ -1701,7 +1721,7 @@ impl ConsequenceAnnotator {
             provider,
             assembly,
             ConsequencePredictorConfigBuilder::default()
-                .report_most_severe_consequence_only(args.report_most_severe_consequence_only)
+                .report_most_severe_consequence_by(args.report_most_severe_consequence_by)
                 .transcript_source(args.transcript_source)
                 .build()?,
         );
@@ -2030,7 +2050,7 @@ mod test {
     use temp_testdir::TempDir;
 
     use super::binning::bin_from_range;
-    use super::{csq::TranscriptSource, run, Args, PathOutput};
+    use super::{csq::TranscriptSource, run, Args, ConsequenceBy, PathOutput};
     use crate::annotate::seqvars::Sources;
 
     #[tokio::test]
@@ -2045,7 +2065,7 @@ mod test {
         let assembly = "grch37";
         let args = Args {
             genome_release: None,
-            report_most_severe_consequence_only: true,
+            report_most_severe_consequence_by: Some(ConsequenceBy::Gene),
             transcript_source: TranscriptSource::Both,
             pick_transcript: vec![],
             pick_transcript_mode: Default::default(),
@@ -2086,7 +2106,7 @@ mod test {
         let assembly = "grch37";
         let args = Args {
             genome_release: None,
-            report_most_severe_consequence_only: false,
+            report_most_severe_consequence_by: Some(ConsequenceBy::Gene),
             transcript_source: TranscriptSource::Both,
             pick_transcript: vec![],
             pick_transcript_mode: Default::default(),
@@ -2139,7 +2159,7 @@ mod test {
         let assembly = "grch37";
         let args = Args {
             genome_release: None,
-            report_most_severe_consequence_only: false,
+            report_most_severe_consequence_by: Some(ConsequenceBy::Gene),
             transcript_source: TranscriptSource::Both,
             pick_transcript: vec![],
             pick_transcript_mode: Default::default(),
@@ -2186,7 +2206,7 @@ mod test {
         let assembly = "grch37";
         let args = Args {
             genome_release: None,
-            report_most_severe_consequence_only: false,
+            report_most_severe_consequence_by: Some(ConsequenceBy::Gene),
             transcript_source: TranscriptSource::Both,
             pick_transcript: vec![],
             pick_transcript_mode: Default::default(),
@@ -2235,7 +2255,7 @@ mod test {
         let assembly = "grch37";
         let args = Args {
             genome_release: None,
-            report_most_severe_consequence_only: false,
+            report_most_severe_consequence_by: Some(ConsequenceBy::Gene),
             transcript_source: TranscriptSource::Both,
             pick_transcript: vec![],
             pick_transcript_mode: Default::default(),
@@ -2284,7 +2304,7 @@ mod test {
         let assembly = "grch38";
         let args = Args {
             genome_release: None,
-            report_most_severe_consequence_only: false,
+            report_most_severe_consequence_by: Some(ConsequenceBy::Gene),
             transcript_source: TranscriptSource::Both,
             pick_transcript: vec![],
             pick_transcript_mode: Default::default(),

--- a/src/annotate/seqvars/mod.rs
+++ b/src/annotate/seqvars/mod.rs
@@ -96,7 +96,7 @@ pub struct Args {
 
     /// Whether to report only the worst consequence for each picked transcript.
     #[arg(long, default_value_t = false)]
-    pub report_worst_consequence_only: bool,
+    pub report_most_severe_consequence_only: bool,
 
     /// Which kind of transcript to pick / restrict to. Default is to keep all.
     /// Depending on `--pick-transcript-mode`, if multiple transcripts match the selection,
@@ -1699,7 +1699,7 @@ impl ConsequenceAnnotator {
             provider,
             assembly,
             ConsequencePredictorConfigBuilder::default()
-                .report_worst_consequence_only(args.report_worst_consequence_only)
+                .report_most_severe_consequence_only(args.report_most_severe_consequence_only)
                 .transcript_source(args.transcript_source)
                 .build()?,
         );
@@ -2043,7 +2043,7 @@ mod test {
         let assembly = "grch37";
         let args = Args {
             genome_release: None,
-            report_worst_consequence_only: true,
+            report_most_severe_consequence_only: true,
             transcript_source: TranscriptSource::Both,
             pick_transcript: vec![],
             pick_transcript_mode: Default::default(),
@@ -2084,7 +2084,7 @@ mod test {
         let assembly = "grch37";
         let args = Args {
             genome_release: None,
-            report_worst_consequence_only: false,
+            report_most_severe_consequence_only: false,
             transcript_source: TranscriptSource::Both,
             pick_transcript: vec![],
             pick_transcript_mode: Default::default(),
@@ -2137,7 +2137,7 @@ mod test {
         let assembly = "grch37";
         let args = Args {
             genome_release: None,
-            report_worst_consequence_only: false,
+            report_most_severe_consequence_only: false,
             transcript_source: TranscriptSource::Both,
             pick_transcript: vec![],
             pick_transcript_mode: Default::default(),
@@ -2184,7 +2184,7 @@ mod test {
         let assembly = "grch37";
         let args = Args {
             genome_release: None,
-            report_worst_consequence_only: false,
+            report_most_severe_consequence_only: false,
             transcript_source: TranscriptSource::Both,
             pick_transcript: vec![],
             pick_transcript_mode: Default::default(),
@@ -2233,7 +2233,7 @@ mod test {
         let assembly = "grch37";
         let args = Args {
             genome_release: None,
-            report_worst_consequence_only: false,
+            report_most_severe_consequence_only: false,
             transcript_source: TranscriptSource::Both,
             pick_transcript: vec![],
             pick_transcript_mode: Default::default(),
@@ -2282,7 +2282,7 @@ mod test {
         let assembly = "grch38";
         let args = Args {
             genome_release: None,
-            report_worst_consequence_only: false,
+            report_most_severe_consequence_only: false,
             transcript_source: TranscriptSource::Both,
             pick_transcript: vec![],
             pick_transcript_mode: Default::default(),

--- a/src/annotate/seqvars/mod.rs
+++ b/src/annotate/seqvars/mod.rs
@@ -1965,12 +1965,12 @@ fn setup_annotator(args: &Args, assembly: Assembly) -> Result<Annotator, Error> 
                     for g2tx in tx_db.gene_to_tx.iter_mut() {
                         if let Some(other_g2tx) = other_gene_to_tx.remove(&g2tx.gene_id) {
                             g2tx.tx_ids.extend(other_g2tx.tx_ids);
-                            g2tx.filtered
-                                .as_mut()
-                                .map(|f| *f &= other_g2tx.filtered.unwrap_or(false));
-                            g2tx.filter_reason
-                                .as_mut()
-                                .map(|r| *r |= other_g2tx.filter_reason.unwrap_or(0));
+                            if let Some(f) = g2tx.filtered.as_mut() {
+                                *f &= other_g2tx.filtered.unwrap_or(false);
+                            }
+                            if let Some(r) = g2tx.filter_reason.as_mut() {
+                                *r |= other_g2tx.filter_reason.unwrap_or(0);
+                            }
                         }
                     }
                     // Add the remaining gene to transcript mappings from the other database.

--- a/src/annotate/seqvars/mod.rs
+++ b/src/annotate/seqvars/mod.rs
@@ -98,15 +98,17 @@ pub struct Args {
     #[arg(long, default_value_t = false)]
     pub report_most_severe_consequence_only: bool,
 
-    /// Which kind of transcript to pick / restrict to. Default is to keep all.
+    /// Which kind of transcript to pick / restrict to. Default is not to pick at all.
+    ///
     /// Depending on `--pick-transcript-mode`, if multiple transcripts match the selection,
     /// either the first one is kept or all are kept.
     #[arg(long)]
     pub pick_transcript: Vec<TranscriptPickType>,
 
+    /// Determines how to handle multiple transcripts. Default is to keep all.
+    ///
     /// When transcript picking is enabled via `--pick-transcript`,
-    /// determines how to handle multiple transcripts:
-    /// Either keep the first one found or keep all that match.
+    /// either keep the first one found or keep all that match.
     #[arg(long, default_value = "all")]
     pub pick_transcript_mode: TranscriptPickMode,
 
@@ -1691,8 +1693,8 @@ impl ConsequenceAnnotator {
             tx_db,
             assembly,
             MehariProviderConfigBuilder::default()
-                .transcript_picking(args.pick_transcript.clone())
-                .transcript_pick_mode(args.pick_transcript_mode)
+                .pick_transcript(args.pick_transcript.clone())
+                .pick_transcript_mode(args.pick_transcript_mode)
                 .build()?,
         ));
         let predictor = ConsequencePredictor::new(

--- a/src/annotate/seqvars/mod.rs
+++ b/src/annotate/seqvars/mod.rs
@@ -1413,7 +1413,7 @@ impl FrequencyAnnotator {
     }
 
     /// Annotate record on autosomal chromosome with gnomAD exomes/genomes.
-    pub fn annotate_record_auto<T>(
+    pub fn annotate_record_auto(
         &self,
         key: &[u8],
         vcf_record: &mut noodles::vcf::variant::RecordBuf,
@@ -1465,7 +1465,7 @@ impl FrequencyAnnotator {
     }
 
     /// Annotate record on gonomosomal chromosome with gnomAD exomes/genomes.
-    pub fn annotate_record_xy<T>(
+    pub fn annotate_record_xy(
         &self,
         key: &[u8],
         vcf_record: &mut noodles::vcf::variant::RecordBuf,
@@ -1529,7 +1529,7 @@ impl FrequencyAnnotator {
     }
 
     /// Annotate record on mitochondrial genome with gnomAD mtDNA and HelixMtDb.
-    pub fn annotate_record_mt<T>(
+    pub fn annotate_record_mt(
         &self,
         key: &[u8],
         vcf_record: &mut noodles::vcf::variant::RecordBuf,
@@ -1580,11 +1580,11 @@ impl FrequencyAnnotator {
 
             // Annotate with frequency.
             if CHROM_AUTO.contains(vcf_var.chrom.as_str()) {
-                self.annotate_record_auto::<MultiThreaded>(&key, record)?;
+                self.annotate_record_auto(&key, record)?;
             } else if CHROM_XY.contains(vcf_var.chrom.as_str()) {
-                self.annotate_record_xy::<MultiThreaded>(&key, record)?;
+                self.annotate_record_xy(&key, record)?;
             } else if CHROM_MT.contains(vcf_var.chrom.as_str()) {
-                self.annotate_record_mt::<MultiThreaded>(&key, record)?;
+                self.annotate_record_mt(&key, record)?;
             } else {
                 tracing::trace!(
                     "Record @{:?} on non-canonical chromosome, skipping.",
@@ -1615,7 +1615,7 @@ impl ClinvarAnnotator {
     }
 
     /// Annotate record with ClinVar information
-    pub fn annotate_record_clinvar<T>(
+    pub fn annotate_record_clinvar(
         &self,
         key: &[u8],
         vcf_record: &mut noodles::vcf::variant::RecordBuf,
@@ -1675,7 +1675,7 @@ impl ClinvarAnnotator {
             let key: Vec<u8> = vcf_var.clone().into();
 
             // Annotate with ClinVar information.
-            self.annotate_record_clinvar::<MultiThreaded>(&key, record)?;
+            self.annotate_record_clinvar(&key, record)?;
         }
         Ok(())
     }

--- a/src/annotate/seqvars/mod.rs
+++ b/src/annotate/seqvars/mod.rs
@@ -99,14 +99,22 @@ pub struct Args {
     pub report_worst_consequence_only: bool,
 
     /// Which kind of transcript to pick / restrict to. Default is to keep all.
-    /// If multiple are given, the first one that is found is kept.
-    #[arg(long, short = 'p')]
+    /// Depending on `--pick-transcript-mode`, if multiple transcripts match the selection,
+    /// either the first one is kept or all are kept.
+    #[arg(long)]
     pub pick_transcript: Vec<TranscriptPickType>,
+
+    /// When transcript picking is enabled via `--pick-transcript`,
+    /// determines how to handle multiple transcripts:
+    /// Either keep the first one found or keep all that match.
+    #[arg(long, default_value_t = TranscriptPickMode::First)]
+    pub pick_transcript_mode: TranscriptPickMode,
 
     /// For debug purposes, maximal number of variants to annotate.
     #[arg(long)]
     pub max_var_count: Option<usize>,
 
+    /// Path to HGNC TSV file.
     #[arg(long, required_unless_present = "path_output_vcf")]
     pub hgnc: Option<String>,
 
@@ -136,6 +144,13 @@ pub enum TranscriptPickType {
     RefSeqSelect,
     GencodePrimary,
     Basic,
+}
+
+#[derive(Debug, Copy, Clone, Display, clap::ValueEnum, Default)]
+pub enum TranscriptPickMode {
+    #[default]
+    First,
+    All,
 }
 
 #[derive(Debug, ClapArgs)]
@@ -1685,6 +1700,7 @@ impl ConsequenceAnnotator {
             assembly,
             MehariProviderConfigBuilder::default()
                 .transcript_picking(args.pick_transcript.clone())
+                .transcript_pick_mode(args.pick_transcript_mode)
                 .build()?,
         ));
         let predictor = ConsequencePredictor::new(
@@ -2038,6 +2054,7 @@ mod test {
             report_worst_consequence_only: true,
             transcript_source: TranscriptSource::Both,
             pick_transcript: vec![],
+            pick_transcript_mode: Default::default(),
             path_input_vcf: String::from("tests/data/annotate/seqvars/brca1.examples.vcf"),
             output: PathOutput {
                 path_output_vcf: Some(path_out.into_os_string().into_string().unwrap()),
@@ -2078,6 +2095,7 @@ mod test {
             report_worst_consequence_only: false,
             transcript_source: TranscriptSource::Both,
             pick_transcript: vec![],
+            pick_transcript_mode: Default::default(),
             path_input_vcf: String::from("tests/data/annotate/seqvars/brca1.examples.vcf"),
             output: PathOutput {
                 path_output_vcf: None,
@@ -2130,6 +2148,7 @@ mod test {
             report_worst_consequence_only: false,
             transcript_source: TranscriptSource::Both,
             pick_transcript: vec![],
+            pick_transcript_mode: Default::default(),
             path_input_vcf: String::from("tests/data/annotate/seqvars/badly_formed_vcf_entry.vcf"),
             output: PathOutput {
                 path_output_vcf: None,
@@ -2176,6 +2195,7 @@ mod test {
             report_worst_consequence_only: false,
             transcript_source: TranscriptSource::Both,
             pick_transcript: vec![],
+            pick_transcript_mode: Default::default(),
             path_input_vcf: String::from("tests/data/annotate/seqvars/mitochondrial_variants.vcf"),
             output: PathOutput {
                 path_output_vcf: None,
@@ -2224,6 +2244,7 @@ mod test {
             report_worst_consequence_only: false,
             transcript_source: TranscriptSource::Both,
             pick_transcript: vec![],
+            pick_transcript_mode: Default::default(),
             path_input_vcf: String::from("tests/data/annotate/seqvars/clair3-glnexus-min.vcf"),
             output: PathOutput {
                 path_output_vcf: None,
@@ -2272,6 +2293,7 @@ mod test {
             report_worst_consequence_only: false,
             transcript_source: TranscriptSource::Both,
             pick_transcript: vec![],
+            pick_transcript_mode: Default::default(),
             path_input_vcf: String::from("tests/data/annotate/seqvars/brca2_zar1l/brca2_zar1l.vcf"),
             output: PathOutput {
                 path_output_vcf: None,

--- a/src/annotate/seqvars/mod.rs
+++ b/src/annotate/seqvars/mod.rs
@@ -448,7 +448,7 @@ impl<Inner: tokio::io::AsyncWrite + Unpin> AsyncAnnotatedVariantWriter
 
     async fn shutdown(&mut self) -> Result<(), Error> {
         Ok(<noodles::bcf::AsyncWriter<Inner>>::get_mut(self)
-            .flush()
+            .shutdown()
             .await?)
     }
 }

--- a/src/annotate/seqvars/mod.rs
+++ b/src/annotate/seqvars/mod.rs
@@ -1417,10 +1417,7 @@ impl FrequencyAnnotator {
         &self,
         key: &[u8],
         vcf_record: &mut noodles::vcf::variant::RecordBuf,
-    ) -> Result<(), Error>
-    where
-        T: ThreadMode,
-    {
+    ) -> Result<(), Error> {
         if let Some(freq) = self
             .db
             .get_cf(self.db.cf_handle("autosomal").as_ref().unwrap(), key)?
@@ -1469,10 +1466,7 @@ impl FrequencyAnnotator {
         &self,
         key: &[u8],
         vcf_record: &mut noodles::vcf::variant::RecordBuf,
-    ) -> Result<(), Error>
-    where
-        T: ThreadMode,
-    {
+    ) -> Result<(), Error> {
         if let Some(freq) = self
             .db
             .get_cf(self.db.cf_handle("gonosomal").as_ref().unwrap(), key)?
@@ -1533,10 +1527,7 @@ impl FrequencyAnnotator {
         &self,
         key: &[u8],
         vcf_record: &mut noodles::vcf::variant::RecordBuf,
-    ) -> Result<(), Error>
-    where
-        T: ThreadMode,
-    {
+    ) -> Result<(), Error> {
         if let Some(freq) = self
             .db
             .get_cf(self.db.cf_handle("mitochondrial").as_ref().unwrap(), key)?

--- a/src/annotate/seqvars/mod.rs
+++ b/src/annotate/seqvars/mod.rs
@@ -1924,9 +1924,14 @@ fn setup_annotator(args: &Args, assembly: Assembly) -> Result<Annotator, Error> 
                         .map(|g2t| (g2t.gene_id.clone(), g2t))
                         .collect();
                     for g2tx in tx_db.gene_to_tx.iter_mut() {
-                        if let Some(other_tx_ids) = other_gene_to_tx.remove(&g2tx.gene_id) {
-                            g2tx.tx_ids.extend(other_tx_ids.tx_ids);
-                            // TODO check g2tx.filter_reason and g2tx.filtered as well
+                        if let Some(other_g2tx) = other_gene_to_tx.remove(&g2tx.gene_id) {
+                            g2tx.tx_ids.extend(other_g2tx.tx_ids);
+                            g2tx.filtered
+                                .as_mut()
+                                .map(|f| *f &= other_g2tx.filtered.unwrap_or(false));
+                            g2tx.filter_reason
+                                .as_mut()
+                                .map(|r| *r |= other_g2tx.filter_reason.unwrap_or(0));
                         }
                     }
                     // Add the remaining gene to transcript mappings from the other database.

--- a/src/annotate/seqvars/mod.rs
+++ b/src/annotate/seqvars/mod.rs
@@ -94,7 +94,7 @@ pub struct Args {
     #[arg(long, value_enum, default_value_t = csq::TranscriptSource::Both)]
     pub transcript_source: csq::TranscriptSource,
 
-    /// Whether to report consequences for all picked transcripts.
+    /// Whether to report only the worst consequence for each picked transcript.
     #[arg(long, default_value_t = false)]
     pub report_worst_consequence_only: bool,
 
@@ -107,7 +107,7 @@ pub struct Args {
     /// When transcript picking is enabled via `--pick-transcript`,
     /// determines how to handle multiple transcripts:
     /// Either keep the first one found or keep all that match.
-    #[arg(long, default_value = "first")]
+    #[arg(long, default_value = "all")]
     pub pick_transcript_mode: TranscriptPickMode,
 
     /// For debug purposes, maximal number of variants to annotate.
@@ -137,8 +137,8 @@ pub struct Args {
     parse_display::FromStr,
 )]
 pub enum TranscriptPickType {
-    ManePlusClinical,
     ManeSelect,
+    ManePlusClinical,
     Length,
     EnsemblCanonical,
     RefSeqSelect,

--- a/src/annotate/seqvars/mod.rs
+++ b/src/annotate/seqvars/mod.rs
@@ -107,7 +107,7 @@ pub struct Args {
     /// When transcript picking is enabled via `--pick-transcript`,
     /// determines how to handle multiple transcripts:
     /// Either keep the first one found or keep all that match.
-    #[arg(long, default_value_t = TranscriptPickMode::First)]
+    #[arg(long, default_value = "first")]
     pub pick_transcript_mode: TranscriptPickMode,
 
     /// For debug purposes, maximal number of variants to annotate.

--- a/src/annotate/seqvars/provider.rs
+++ b/src/annotate/seqvars/provider.rs
@@ -81,7 +81,7 @@ impl TxIntervalTrees {
                 let contig = &genome_alignment.contig;
                 if let Some(contig_idx) = contig_to_idx.get(contig) {
                     let mut start = i32::MAX;
-                    let mut stop = std::i32::MIN;
+                    let mut stop = i32::MIN;
                     for exon in &genome_alignment.exons {
                         start = std::cmp::min(start, exon.alt_start_i);
                         stop = std::cmp::max(stop, exon.alt_end_i);

--- a/src/annotate/seqvars/provider.rs
+++ b/src/annotate/seqvars/provider.rs
@@ -80,7 +80,7 @@ impl TxIntervalTrees {
             for genome_alignment in &tx.genome_alignments {
                 let contig = &genome_alignment.contig;
                 if let Some(contig_idx) = contig_to_idx.get(contig) {
-                    let mut start = std::i32::MAX;
+                    let mut start = i32::MAX;
                     let mut stop = std::i32::MIN;
                     for exon in &genome_alignment.exons {
                         start = std::cmp::min(start, exon.alt_start_i);
@@ -542,11 +542,11 @@ impl ProviderInterface for Provider {
                         cigar: exon.cigar.clone(),
                         tx_aseq: None,
                         alt_aseq: None,
-                        tx_exon_set_id: std::i32::MAX,
-                        alt_exon_set_id: std::i32::MAX,
-                        tx_exon_id: std::i32::MAX,
-                        alt_exon_id: std::i32::MAX,
-                        exon_aln_id: std::i32::MAX,
+                        tx_exon_set_id: i32::MAX,
+                        alt_exon_set_id: i32::MAX,
+                        tx_exon_id: i32::MAX,
+                        alt_exon_id: i32::MAX,
+                        exon_aln_id: i32::MAX,
                     })
                     .collect());
             }

--- a/src/annotate/seqvars/provider.rs
+++ b/src/annotate/seqvars/provider.rs
@@ -2,6 +2,12 @@
 
 use std::collections::HashMap;
 
+use crate::annotate::seqvars::TranscriptPickType;
+use crate::db::create::Reason;
+use crate::{
+    annotate::seqvars::csq::ALT_ALN_METHOD,
+    pbs::txs::{GeneToTxId, Strand, Transcript, TranscriptTag, TxSeqDatabase},
+};
 use annonars::common::cli::CANONICAL;
 use bio::data_structures::interval_tree::ArrayBackedIntervalTree;
 use biocommons_bioutils::assemblies::{Assembly, ASSEMBLY_INFOS};
@@ -16,11 +22,7 @@ use hgvs::{
     },
     sequences::{seq_md5, TranslationTable},
 };
-
-use crate::{
-    annotate::seqvars::csq::ALT_ALN_METHOD,
-    pbs::txs::{GeneToTxId, Strand, Transcript, TranscriptTag, TxSeqDatabase},
-};
+use itertools::Itertools;
 
 /// Mitochondrial accessions.
 const MITOCHONDRIAL_ACCESSIONS: &[&str] = &[
@@ -105,8 +107,8 @@ pub struct Config {
     /// Whether to use transcript picking.  When enabled, only use (a)
     /// ManeSelect+ManePlusClinical, (b) ManeSelect, (c) longest transcript
     /// (the first available).
-    #[builder(default = "false")]
-    pub transcript_picking: bool,
+    #[builder(default)]
+    pub transcript_picking: Vec<TranscriptPickType>,
 }
 
 /// Provider based on the protobuf `TxSeqDatabase`.
@@ -128,6 +130,22 @@ pub struct Provider {
     assembly: Assembly,
     data_version: String,
     schema_version: String,
+}
+
+fn transcript_length(tx: &Transcript) -> i32 {
+    let mut max_tx_length = 0;
+    for genome_alignment in tx.genome_alignments.iter() {
+        // We just count length in reference so we don't have to look
+        // into the CIGAR string.
+        let mut tx_length = 0;
+        for exon_alignment in genome_alignment.exons.iter() {
+            tx_length += exon_alignment.alt_cds_end_i() - exon_alignment.alt_cds_start_i();
+        }
+        if tx_length > max_tx_length {
+            max_tx_length = tx_length;
+        }
+    }
+    max_tx_length
 }
 
 impl Provider {
@@ -181,7 +199,7 @@ impl Provider {
 
         // When transcript picking is enabled, restrict to ManeSelect and ManePlusClinical if
         // we have any such transcript.  Otherwise, fall back to the longest transcript.
-        let picked_gene_to_tx_id = if config.transcript_picking {
+        let picked_gene_to_tx_id = if !config.transcript_picking.is_empty() {
             if let Some(tx_db) = tx_seq_db.tx_db.as_mut() {
                 // The new gene-to-txid mapping we will build.
                 let mut new_gene_to_tx = Vec::new();
@@ -189,75 +207,84 @@ impl Provider {
                 // Process each gene.
                 for entry in tx_db.gene_to_tx.iter() {
                     // First, determine whether we have any MANE transcripts.
-                    let mane_tx_ids = entry
+                    let mut longest_tx_id = None;
+                    let mut tx_tags = entry
                         .tx_ids
                         .iter()
-                        .filter(|tx_id| {
-                            tx_map
-                                .get(*tx_id)
-                                .map(|tx_idx| {
-                                    let tx = &tx_db.transcripts[*tx_idx as usize];
-                                    tx.tags.contains(&TranscriptTag::ManePlusClinical.into())
-                                        || tx.tags.contains(&TranscriptTag::ManeSelect.into())
-                                })
-                                .unwrap_or_default()
+                        .enumerate()
+                        .filter_map(|(i, tx_id)| {
+                            tx_map.get(tx_id).map(|tx_idx| {
+                                let tx = &tx_db.transcripts[*tx_idx as usize];
+                                let tags = tx
+                                    .tags
+                                    .iter()
+                                    .filter_map(|tag| {
+                                        match TranscriptTag::try_from(*tag).unwrap() {
+                                            TranscriptTag::Unknown => None,
+                                            TranscriptTag::Basic => Some(TranscriptPickType::Basic),
+                                            TranscriptTag::EnsemblCanonical => {
+                                                Some(TranscriptPickType::EnsemblCanonical)
+                                            }
+                                            TranscriptTag::ManeSelect => {
+                                                Some(TranscriptPickType::ManeSelect)
+                                            }
+                                            TranscriptTag::ManePlusClinical => {
+                                                Some(TranscriptPickType::ManePlusClinical)
+                                            }
+                                            TranscriptTag::RefSeqSelect => {
+                                                Some(TranscriptPickType::RefSeqSelect)
+                                            }
+                                            TranscriptTag::Selenoprotein => None,
+                                            TranscriptTag::GencodePrimary => {
+                                                Some(TranscriptPickType::GencodePrimary)
+                                            }
+                                        }
+                                    })
+                                    .collect_vec();
+                                let length = transcript_length(tx);
+                                if let Some((prev_i, prev_length)) = longest_tx_id.as_mut() {
+                                    if length > *prev_length {
+                                        *prev_i = i;
+                                        *prev_length = length;
+                                    }
+                                } else {
+                                    longest_tx_id = Some((i, length));
+                                }
+                                (tx_id, tags, length)
+                            })
                         })
-                        .cloned()
-                        .collect::<Vec<_>>();
+                        .collect_vec();
+                    if let Some((i, _)) = longest_tx_id {
+                        tx_tags[i].1.push(TranscriptPickType::Length);
+                    }
 
-                    // Now, construct gene-to-txid mapping entry.
-                    let new_entry = if !mane_tx_ids.is_empty() {
-                        // For the case that we have MANE transcripts.
+                    // only keep the first transcript that fulfills the transcript picking strategy,
+                    // if any
+                    let tx_id = config
+                        .transcript_picking
+                        .iter()
+                        .filter_map(|pick| {
+                            tx_tags
+                                .iter()
+                                .find(|(_, tags, _)| tags.contains(pick))
+                                .map(|(tx_id, _, _)| tx_id)
+                        })
+                        .next();
+
+                    let new_entry = if let Some(tx_id) = tx_id {
                         GeneToTxId {
                             gene_id: entry.gene_id.clone(),
-                            tx_ids: mane_tx_ids,
+                            tx_ids: vec![tx_id.to_string()],
                             filtered: Some(false),
                             filter_reason: None,
                         }
                     } else {
-                        // Otherwise, determine the longest transcript's length.
-                        if let Some((_, tx_id)) = entry
-                            .tx_ids
-                            .iter()
-                            .map(|tx_id| {
-                                tx_map
-                                    .get(tx_id)
-                                    .map(|tx_idx| {
-                                        // A slight complication, we need to look at all genome alignments...
-                                        let tx = &tx_db.transcripts[*tx_idx as usize];
-                                        let mut max_tx_length = 0;
-                                        for genome_alignment in tx.genome_alignments.iter() {
-                                            // We just count length in reference so we don't have to look
-                                            // into the CIGAR string.
-                                            let mut tx_length = 0;
-                                            for exon_alignment in genome_alignment.exons.iter() {
-                                                tx_length += exon_alignment.alt_cds_end_i()
-                                                    - exon_alignment.alt_cds_start_i();
-                                            }
-                                            if tx_length > max_tx_length {
-                                                max_tx_length = tx_length;
-                                            }
-                                        }
-                                        (max_tx_length, tx_id.clone())
-                                    })
-                                    .unwrap_or_default()
-                            })
-                            .max()
-                        {
-                            GeneToTxId {
-                                gene_id: entry.gene_id.clone(),
-                                tx_ids: vec![tx_id],
-                                filtered: Some(false),
-                                filter_reason: None,
-                            }
-                        } else {
-                            // No transcripts for this gene.
-                            GeneToTxId {
-                                gene_id: entry.gene_id.clone(),
-                                tx_ids: Vec::new(),
-                                filtered: Some(true),
-                                filter_reason: Some(crate::db::create::Reason::NoTranscripts as u32),
-                            }
+                        tracing::trace!("no transcript found for gene {} with the chosen transcript picking strategy: {:?}", &entry.gene_id, &config.transcript_picking);
+                        GeneToTxId {
+                            gene_id: entry.gene_id.clone(),
+                            tx_ids: vec![],
+                            filtered: Some(true),
+                            filter_reason: Some(Reason::NoTranscriptLeft as u32),
                         }
                     };
 

--- a/src/annotate/seqvars/provider.rs
+++ b/src/annotate/seqvars/provider.rs
@@ -216,7 +216,7 @@ impl Provider {
                         }
                     } else {
                         // Otherwise, determine the longest transcript's length.
-                        let (_, tx_id) = entry
+                        if let Some((_, tx_id)) = entry
                             .tx_ids
                             .iter()
                             .map(|tx_id| {
@@ -243,13 +243,21 @@ impl Provider {
                                     .unwrap_or_default()
                             })
                             .max()
-                            .unwrap_or_else(|| panic!("no length for gene {}", &entry.gene_id));
-
-                        GeneToTxId {
-                            gene_id: entry.gene_id.clone(),
-                            tx_ids: vec![tx_id],
-                            filtered: Some(false),
-                            filter_reason: None,
+                        {
+                            GeneToTxId {
+                                gene_id: entry.gene_id.clone(),
+                                tx_ids: vec![tx_id],
+                                filtered: Some(false),
+                                filter_reason: None,
+                            }
+                        } else {
+                            // No transcripts for this gene.
+                            GeneToTxId {
+                                gene_id: entry.gene_id.clone(),
+                                tx_ids: Vec::new(),
+                                filtered: Some(true),
+                                filter_reason: Some(crate::db::create::Reason::NoTranscripts as u32),
+                            }
                         }
                     };
 

--- a/src/common/noodles.rs
+++ b/src/common/noodles.rs
@@ -41,9 +41,9 @@ pub async fn open_bcf_reader(path: impl AsRef<Path>) -> Result<AsyncBcfReader, E
 }
 
 pub async fn open_variant_reader(path: impl AsRef<Path>) -> anyhow::Result<VariantReader> {
+    #[allow(clippy::wildcard_in_or_patterns)]
     match path.as_ref().extension().and_then(|s| s.to_str()) {
         Some("bcf") => open_bcf_reader(path).await.map(VariantReader::Bcf),
-        #[allow(clippy::wildcard_in_or_patterns)]
         Some("gz") | Some("vcf") | _ => open_vcf_reader(path).await.map(VariantReader::Vcf),
     }
 }
@@ -125,9 +125,9 @@ pub async fn open_bcf_writer(path: impl AsRef<Path>) -> Result<AsyncBcfWriter, E
 }
 
 pub async fn open_variant_writer(path: impl AsRef<Path>) -> anyhow::Result<VariantWriter> {
+    #[allow(clippy::wildcard_in_or_patterns)]
     match path.as_ref().extension().and_then(|s| s.to_str()) {
         Some("bcf") => open_bcf_writer(path).await.map(VariantWriter::Bcf),
-        #[allow(clippy::wildcard_in_or_patterns)]
         Some("gz") | Some("vcf") | _ => open_vcf_writer(path).await.map(VariantWriter::Vcf),
     }
 }

--- a/src/db/check/mod.rs
+++ b/src/db/check/mod.rs
@@ -321,7 +321,7 @@ pub fn run(_common: &crate::common::Args, args: &Args) -> Result<()> {
     let mut report = Vec::new();
 
     // Load the transcript database
-    let tx_db = load_tx_db(&format!("{}", args.db.display()))?
+    let tx_db = load_tx_db(format!("{}", args.db.display()))?
         .tx_db
         .unwrap();
     // … and determine all Ids that have been filtered out

--- a/src/db/check/mod.rs
+++ b/src/db/check/mod.rs
@@ -321,9 +321,7 @@ pub fn run(_common: &crate::common::Args, args: &Args) -> Result<()> {
     let mut report = Vec::new();
 
     // Load the transcript database
-    let tx_db = load_tx_db(format!("{}", args.db.display()))?
-        .tx_db
-        .unwrap();
+    let tx_db = load_tx_db(format!("{}", args.db.display()))?.tx_db.unwrap();
     // … and determine all Ids that have been filtered out
     let filtered_ids: HashSet<Id> = tx_db
         .gene_to_tx

--- a/src/db/create/mod.rs
+++ b/src/db/create/mod.rs
@@ -155,7 +155,7 @@ impl TranscriptExt for Transcript {
     }
 
     fn is_on_contig(&self, contig: &str) -> bool {
-        self.genome_builds.values().any(|gb| &gb.contig == contig)
+        self.genome_builds.values().any(|gb| gb.contig == contig)
     }
 }
 
@@ -276,7 +276,7 @@ impl TranscriptLoader {
                 } else {
                     txid
                 };
-                tx.id = txid.clone();
+                tx.id.clone_from(&txid);
                 TranscriptId::try_new(txid).map(|t| (t, tx))
             })
             .collect::<Result<HashMap<_, _>, _>>()?;

--- a/src/db/dump/mod.rs
+++ b/src/db/dump/mod.rs
@@ -22,7 +22,7 @@ pub fn run_with_write<W: Write>(
     writer: &mut W,
 ) -> Result<(), anyhow::Error> {
     tracing::info!("Opening transcript database");
-    let tx_db = load_tx_db(&format!("{}", args.path_db.display()))?;
+    let tx_db = load_tx_db(format!("{}", args.path_db.display()))?;
     tracing::info!("Dumping ...");
     serde_yaml::to_writer(writer, &tx_db)?;
     tracing::info!("... done");

--- a/src/db/subset/mod.rs
+++ b/src/db/subset/mod.rs
@@ -123,7 +123,7 @@ fn subset_tx_db(
 /// Main entry point.
 pub fn run(_common: &crate::common::Args, args: &Args) -> Result<(), anyhow::Error> {
     tracing::info!("Opening transcript database");
-    let tx_db = load_tx_db(&format!("{}", args.path_in.display()))?;
+    let tx_db = load_tx_db(format!("{}", args.path_in.display()))?;
 
     tracing::info!("Subsetting ...");
     let tx_db = subset_tx_db(&tx_db, &args.gene_symbols)?;

--- a/src/verify/seqvars.rs
+++ b/src/verify/seqvars.rs
@@ -11,7 +11,7 @@ use crate::annotate::seqvars::{
     csq::{ConfigBuilder as ConsequencePredictorConfigBuilder, ConsequencePredictor, VcfVariant},
     load_tx_db, path_component,
     provider::{ConfigBuilder as MehariProviderConfigBuilder, Provider as MehariProvider},
-    TranscriptPickType,
+    TranscriptPickMode, TranscriptPickType,
 };
 use biocommons_bioutils::assemblies::Assembly;
 use clap::Parser;
@@ -42,9 +42,17 @@ pub struct Args {
     #[arg(long, default_value_t = false)]
     pub report_worst_consequence_only: bool,
 
-    /// Which kind of transcripts to pick / restrict to. Default is to keep all.
-    #[arg(long, short = 'p')]
+    /// Which kind of transcript to pick / restrict to. Default is to keep all.
+    /// Depending on `--pick-transcript-mode`, if multiple transcripts match the selection,
+    /// either the first one is kept or all are kept.
+    #[arg(long)]
     pub pick_transcript: Vec<TranscriptPickType>,
+
+    /// When transcript picking is enabled via `--pick-transcript`,
+    /// determines how to handle multiple transcripts:
+    /// Either keep the first one found or keep all that match.
+    #[arg(long, default_value_t = TranscriptPickMode::First)]
+    pub pick_transcript_mode: TranscriptPickMode,
 
     /// For debug purposes, maximal number of variants to annotate.
     #[arg(long)]
@@ -140,6 +148,7 @@ pub fn run(_common: &crate::common::Args, args: &Args) -> Result<(), anyhow::Err
         assembly,
         MehariProviderConfigBuilder::default()
             .transcript_picking(args.pick_transcript.clone())
+            .transcript_pick_mode(args.pick_transcript_mode)
             .build()?,
     ));
 

--- a/src/verify/seqvars.rs
+++ b/src/verify/seqvars.rs
@@ -42,15 +42,17 @@ pub struct Args {
     #[arg(long, default_value_t = false)]
     pub report_most_severe_consequence_only: bool,
 
-    /// Which kind of transcript to pick / restrict to. Default is to keep all.
+    /// Which kind of transcript to pick / restrict to. Default is not to pick at all.
+    ///
     /// Depending on `--pick-transcript-mode`, if multiple transcripts match the selection,
     /// either the first one is kept or all are kept.
     #[arg(long)]
     pub pick_transcript: Vec<TranscriptPickType>,
 
+    /// Determines how to handle multiple transcripts. Default is to keep all.
+    ///
     /// When transcript picking is enabled via `--pick-transcript`,
-    /// determines how to handle multiple transcripts:
-    /// Either keep the first one found or keep all that match.
+    /// either keep the first one found or keep all that match.
     #[arg(long, default_value = "all")]
     pub pick_transcript_mode: TranscriptPickMode,
 
@@ -147,8 +149,8 @@ pub fn run(_common: &crate::common::Args, args: &Args) -> Result<(), anyhow::Err
         tx_db,
         assembly,
         MehariProviderConfigBuilder::default()
-            .transcript_picking(args.pick_transcript.clone())
-            .transcript_pick_mode(args.pick_transcript_mode)
+            .pick_transcript(args.pick_transcript.clone())
+            .pick_transcript_mode(args.pick_transcript_mode)
             .build()?,
     ));
 

--- a/src/verify/seqvars.rs
+++ b/src/verify/seqvars.rs
@@ -11,7 +11,7 @@ use crate::annotate::seqvars::{
     csq::{ConfigBuilder as ConsequencePredictorConfigBuilder, ConsequencePredictor, VcfVariant},
     load_tx_db, path_component,
     provider::{ConfigBuilder as MehariProviderConfigBuilder, Provider as MehariProvider},
-    TranscriptPickMode, TranscriptPickType,
+    ConsequenceBy, TranscriptPickMode, TranscriptPickType,
 };
 use biocommons_bioutils::assemblies::Assembly;
 use clap::Parser;
@@ -39,8 +39,8 @@ pub struct Args {
     pub path_output_tsv: String,
 
     /// Whether to report only the worst consequence for each picked transcript.
-    #[arg(long, default_value_t = false)]
-    pub report_most_severe_consequence_only: bool,
+    #[arg(long)]
+    pub report_most_severe_consequence_by: Option<ConsequenceBy>,
 
     /// Which kind of transcript to pick / restrict to. Default is not to pick at all.
     ///
@@ -158,7 +158,7 @@ pub fn run(_common: &crate::common::Args, args: &Args) -> Result<(), anyhow::Err
         provider,
         assembly,
         ConsequencePredictorConfigBuilder::default()
-            .report_most_severe_consequence_only(args.report_most_severe_consequence_only)
+            .report_most_severe_consequence_by(args.report_most_severe_consequence_by)
             .build()?,
     );
 

--- a/src/verify/seqvars.rs
+++ b/src/verify/seqvars.rs
@@ -40,7 +40,7 @@ pub struct Args {
 
     /// Whether to report only the worst consequence for each picked transcript.
     #[arg(long, default_value_t = false)]
-    pub report_worst_consequence_only: bool,
+    pub report_most_severe_consequence_only: bool,
 
     /// Which kind of transcript to pick / restrict to. Default is to keep all.
     /// Depending on `--pick-transcript-mode`, if multiple transcripts match the selection,
@@ -156,7 +156,7 @@ pub fn run(_common: &crate::common::Args, args: &Args) -> Result<(), anyhow::Err
         provider,
         assembly,
         ConsequencePredictorConfigBuilder::default()
-            .report_worst_consequence_only(args.report_worst_consequence_only)
+            .report_most_severe_consequence_only(args.report_most_severe_consequence_only)
             .build()?,
     );
 

--- a/src/verify/seqvars.rs
+++ b/src/verify/seqvars.rs
@@ -51,7 +51,7 @@ pub struct Args {
     /// When transcript picking is enabled via `--pick-transcript`,
     /// determines how to handle multiple transcripts:
     /// Either keep the first one found or keep all that match.
-    #[arg(long, default_value_t = TranscriptPickMode::First)]
+    #[arg(long, default_value = "first")]
     pub pick_transcript_mode: TranscriptPickMode,
 
     /// For debug purposes, maximal number of variants to annotate.

--- a/src/verify/seqvars.rs
+++ b/src/verify/seqvars.rs
@@ -137,7 +137,7 @@ pub fn run(_common: &crate::common::Args, args: &Args) -> Result<(), anyhow::Err
 
     // Read the serialized transcripts.
     tracing::info!("Opening transcript database");
-    let tx_db = load_tx_db(&format!(
+    let tx_db = load_tx_db(format!(
         "{}/{}/txs.bin.zst",
         &args.path_db,
         path_component(assembly)

--- a/src/verify/seqvars.rs
+++ b/src/verify/seqvars.rs
@@ -38,7 +38,7 @@ pub struct Args {
     #[arg(long)]
     pub path_output_tsv: String,
 
-    /// Whether to report consequences for all picked transcripts.
+    /// Whether to report only the worst consequence for each picked transcript.
     #[arg(long, default_value_t = false)]
     pub report_worst_consequence_only: bool,
 
@@ -51,7 +51,7 @@ pub struct Args {
     /// When transcript picking is enabled via `--pick-transcript`,
     /// determines how to handle multiple transcripts:
     /// Either keep the first one found or keep all that match.
-    #[arg(long, default_value = "first")]
+    #[arg(long, default_value = "all")]
     pub pick_transcript_mode: TranscriptPickMode,
 
     /// For debug purposes, maximal number of variants to annotate.


### PR DESCRIPTION
This allows specifying any combination of `--clinvar /path/to/clinvar/rocksdb --frequencies /path/to/gnomad_freqs/rocksdb --transcripts /path/to/mehari/txdb` so only the requested annotation is actually annotated.
At the same time, only the respective requested databases actually need to exist, e.g. when specifying `--transcripts …` by itself, only the transcript database needs to exist.
Additionally, `--transcripts` may be provided multiple times, and the respective transcript dbs are merged (e.g. when you want to annotate both refseq and ensembl transcripts)

Additionally, the way transcript picking and consequence reporting is done has also been refactored:
- the flag `--transcript-picking` is now `--pick-transcript TAG` and can be specified multiple times, and the order matters
- `TAG` can be any of:
  - `mane-select`
  - `mane-plus-clinical`
  - `length` (→ the longest available transcript)
  - `ensembl-canonical`
  - `ref-seq-select`
  - `gencode-primary`
  - `basic`
- `--pick-transcript-mode MODE` controls whether:
  - `first`: check each of the provided `TAG`s in order and keep only the first transcript that matches, e.g. if `--pick-transcript mane-select` and `--pick-transcript mane-plus-clinical` have been provided, check if any transcript matches `mane-select` and keep only the first one; if none match `mane-select`, find the first `mane-plus-clinical` transcript. It probably makes sense to have `--pick-transcript length` as the last entry as a fallback.
  -  `all`: keep all transcripts that match any of the provided `TAG`s.
- `--report-all-transcripts` has been replaced with `--report-most-severe-consequence-by TYPE`, to be able to mimick vep transcript picking a bit better,
  - `TYPE` currently can be one of:
    - `gene` (this used to be the default behaviour until now)
    - `transcript`
    - `allele` (which, since we do not support multi-allelic VCF records, is equivalent to per record)

