### PR TITLE
fix: codon deletion right in front of stop codon is not a stop_gained

### DIFF
--- a/src/annotate/seqvars/csq.rs
+++ b/src/annotate/seqvars/csq.rs
@@ -1064,24 +1064,41 @@ mod test {
     /// The order of the consequences is important: ordered by severity, descending.
     /// cf Consequences enum ordering.
     #[rstest::rstest]
-    #[case("17:41197820:G:T", 1, vec![Consequence::SpliceAcceptorVariant, Consequence::IntronVariant])] // 1bp intronic
-    #[case("17:41197821:A:C", 2, vec![Consequence::SpliceAcceptorVariant, Consequence::IntronVariant])] // 2bp intronic
-    #[case("17:41197822:C:A", 3, vec![Consequence::SpliceRegionVariant, Consequence::SplicePolypyrimidineTractVariant, Consequence::IntronVariant])] // 3bp intronic
-    #[case("17:41197823:C:A", 4, vec![Consequence::SpliceRegionVariant, Consequence::SplicePolypyrimidineTractVariant, Consequence::IntronVariant])] // 4bp intronic
-    #[case("17:41197824:T:G", 5, vec![Consequence::SpliceRegionVariant, Consequence::SplicePolypyrimidineTractVariant, Consequence::IntronVariant])] // 5bp intronic
-    #[case("17:41197825:C:A", 6, vec![Consequence::SpliceRegionVariant, Consequence::SplicePolypyrimidineTractVariant, Consequence::IntronVariant])] // 6bp intronic
-    #[case("17:41197835:T:G", 16, vec![Consequence::SplicePolypyrimidineTractVariant, Consequence::IntronVariant])] // 16bp intronic
-    #[case("17:41197836:G:A", 17, vec![Consequence::SplicePolypyrimidineTractVariant, Consequence::IntronVariant])] // 17bp intronic
+    #[case("17:41197820:G:T", 1, vec![Consequence::SpliceAcceptorVariant, Consequence::IntronVariant]
+    )] // 1bp intronic
+    #[case("17:41197821:A:C", 2, vec![Consequence::SpliceAcceptorVariant, Consequence::IntronVariant]
+    )] // 2bp intronic
+    #[case("17:41197822:C:A", 3, vec![Consequence::SpliceRegionVariant, Consequence::SplicePolypyrimidineTractVariant, Consequence::IntronVariant]
+    )] // 3bp intronic
+    #[case("17:41197823:C:A", 4, vec![Consequence::SpliceRegionVariant, Consequence::SplicePolypyrimidineTractVariant, Consequence::IntronVariant]
+    )] // 4bp intronic
+    #[case("17:41197824:T:G", 5, vec![Consequence::SpliceRegionVariant, Consequence::SplicePolypyrimidineTractVariant, Consequence::IntronVariant]
+    )] // 5bp intronic
+    #[case("17:41197825:C:A", 6, vec![Consequence::SpliceRegionVariant, Consequence::SplicePolypyrimidineTractVariant, Consequence::IntronVariant]
+    )] // 6bp intronic
+    #[case("17:41197835:T:G", 16, vec![Consequence::SplicePolypyrimidineTractVariant, Consequence::IntronVariant]
+    )] // 16bp intronic
+    #[case("17:41197836:G:A", 17, vec![Consequence::SplicePolypyrimidineTractVariant, Consequence::IntronVariant]
+    )] // 17bp intronic
     #[case("17:41197837:G:A", 18, vec![Consequence::IntronVariant])] // 18bp intronic
-    #[case("17:41199660:G:T", 0, vec![Consequence::MissenseVariant, Consequence::SpliceRegionVariant])] // exonic
-    #[case("17:41199659:G:T", -1, vec![Consequence::SpliceDonorVariant, Consequence::IntronVariant])] // -1bp intronic
-    #[case("17:41199658:T:G", -2, vec![Consequence::SpliceDonorVariant, Consequence::IntronVariant])] // -2bp intronic
-    #[case("17:41199657:G:T", -3, vec![Consequence::SpliceRegionVariant, Consequence::SpliceDonorRegionVariant, Consequence::IntronVariant])] // -3bp intronic
-    #[case("17:41199656:A:C", -4, vec![Consequence::SpliceRegionVariant, Consequence::SpliceDonorRegionVariant, Consequence::IntronVariant])] // -4bp intronic
-    #[case("17:41199655:G:T", -5, vec![Consequence::SpliceDonorFifthBaseVariant, Consequence::SpliceRegionVariant, Consequence::SpliceDonorRegionVariant, Consequence::IntronVariant])] // -5bp intronic
-    #[case("17:41199654:G:T", -6, vec![Consequence::SpliceRegionVariant, Consequence::SpliceDonorRegionVariant, Consequence::IntronVariant])] // -6bp intronic
-    #[case("17:41199653:T:G", -7, vec![Consequence::SpliceRegionVariant, Consequence::IntronVariant])] // -7bp intronic
-    #[case("17:41199652:G:T", -8, vec![Consequence::SpliceRegionVariant, Consequence::IntronVariant])] // -8bp intronic
+    #[case("17:41199660:G:T", 0, vec![Consequence::MissenseVariant, Consequence::SpliceRegionVariant]
+    )] // exonic
+    #[case("17:41199659:G:T", -1, vec![Consequence::SpliceDonorVariant, Consequence::IntronVariant]
+    )] // -1bp intronic
+    #[case("17:41199658:T:G", -2, vec![Consequence::SpliceDonorVariant, Consequence::IntronVariant]
+    )] // -2bp intronic
+    #[case("17:41199657:G:T", -3, vec![Consequence::SpliceRegionVariant, Consequence::SpliceDonorRegionVariant, Consequence::IntronVariant]
+    )] // -3bp intronic
+    #[case("17:41199656:A:C", -4, vec![Consequence::SpliceRegionVariant, Consequence::SpliceDonorRegionVariant, Consequence::IntronVariant]
+    )] // -4bp intronic
+    #[case("17:41199655:G:T", -5, vec![Consequence::SpliceDonorFifthBaseVariant, Consequence::SpliceRegionVariant, Consequence::SpliceDonorRegionVariant, Consequence::IntronVariant]
+    )] // -5bp intronic
+    #[case("17:41199654:G:T", -6, vec![Consequence::SpliceRegionVariant, Consequence::SpliceDonorRegionVariant, Consequence::IntronVariant]
+    )] // -6bp intronic
+    #[case("17:41199653:T:G", -7, vec![Consequence::SpliceRegionVariant, Consequence::IntronVariant]
+    )] // -7bp intronic
+    #[case("17:41199652:G:T", -8, vec![Consequence::SpliceRegionVariant, Consequence::IntronVariant]
+    )] // -8bp intronic
     #[case("17:41199651:C:A", -9, vec![Consequence::IntronVariant])] // -9bp intronic
     fn annotate_snv_brca1_csq(
         #[case] spdi: &str,
@@ -1138,24 +1155,42 @@ mod test {
     /// The order of the consequences is important: ordered by severity, descending.
     /// cf Consequences enum ordering.
     #[rstest::rstest]
-    #[case("3:193332512:T:G", 0, vec![Consequence::MissenseVariant, Consequence::SpliceRegionVariant])] // exonic
-    #[case("3:193332511:G:T", -1, vec![Consequence::SpliceAcceptorVariant, Consequence::IntronVariant])] // -1bp intronic
-    #[case("3:193332510:A:G", -2, vec![Consequence::SpliceAcceptorVariant, Consequence::IntronVariant])] // -2bp intronic
-    #[case("3:193332509:C:T", -3, vec![Consequence::SpliceRegionVariant, Consequence::SplicePolypyrimidineTractVariant,  Consequence::IntronVariant])] // -3bp intronic
-    #[case("3:193332508:T:C", -4, vec![Consequence::SpliceRegionVariant, Consequence::SplicePolypyrimidineTractVariant,  Consequence::IntronVariant])] // -4bp intronic
-    #[case("3:193332507:T:C", -5, vec![Consequence::SpliceRegionVariant, Consequence::SplicePolypyrimidineTractVariant,  Consequence::IntronVariant])] // -5bp intronic
-    #[case("3:193332506:T:C", -6, vec![Consequence::SpliceRegionVariant, Consequence::SplicePolypyrimidineTractVariant, Consequence::IntronVariant])] // -6bp intronic
-    #[case("3:193332505:C:G", -7, vec![Consequence::SpliceRegionVariant, Consequence::SplicePolypyrimidineTractVariant, Consequence::IntronVariant])] // -7bp intronic
-    #[case("3:193332504:T:C", -8, vec![Consequence::SpliceRegionVariant, Consequence::SplicePolypyrimidineTractVariant, Consequence::IntronVariant])] // -8bp intronic
-    #[case("3:193332503:T:A", -9, vec![Consequence::SplicePolypyrimidineTractVariant, Consequence::IntronVariant])] // -9bp intronic
-    #[case("3:193332831:G:T", 1, vec![Consequence::SpliceDonorVariant, Consequence::IntronVariant])] // 1bp intronic
-    #[case("3:193332832:T:C", 2, vec![Consequence::SpliceDonorVariant, Consequence::IntronVariant])] // 2bp intronic
-    #[case("3:193332833:G:A", 3, vec![Consequence::SpliceRegionVariant, Consequence::SpliceDonorRegionVariant, Consequence::IntronVariant])] // 3bp intronic
-    #[case("3:193332834:A:C", 4, vec![Consequence::SpliceRegionVariant, Consequence::SpliceDonorRegionVariant, Consequence::IntronVariant])] // 4bp intronic
-    #[case("3:193332835:A:T", 5, vec![Consequence::SpliceDonorFifthBaseVariant, Consequence::SpliceRegionVariant, Consequence::SpliceDonorRegionVariant, Consequence::IntronVariant])] // 5bp intronic
-    #[case("3:193332836:C:A", 6, vec![Consequence::SpliceRegionVariant, Consequence::SpliceDonorRegionVariant, Consequence::IntronVariant])] // 6bp intronic
-    #[case("3:193332837:T:G", 7, vec![Consequence::SpliceRegionVariant, Consequence::IntronVariant])] // 7bp intronic
-    #[case("3:193332838:T:G", 8, vec![Consequence::SpliceRegionVariant, Consequence::IntronVariant])] // 8bp intronic
+    #[case("3:193332512:T:G", 0, vec![Consequence::MissenseVariant, Consequence::SpliceRegionVariant]
+    )] // exonic
+    #[case("3:193332511:G:T", -1, vec![Consequence::SpliceAcceptorVariant, Consequence::IntronVariant]
+    )] // -1bp intronic
+    #[case("3:193332510:A:G", -2, vec![Consequence::SpliceAcceptorVariant, Consequence::IntronVariant]
+    )] // -2bp intronic
+    #[case("3:193332509:C:T", -3, vec![Consequence::SpliceRegionVariant, Consequence::SplicePolypyrimidineTractVariant,  Consequence::IntronVariant]
+    )] // -3bp intronic
+    #[case("3:193332508:T:C", -4, vec![Consequence::SpliceRegionVariant, Consequence::SplicePolypyrimidineTractVariant,  Consequence::IntronVariant]
+    )] // -4bp intronic
+    #[case("3:193332507:T:C", -5, vec![Consequence::SpliceRegionVariant, Consequence::SplicePolypyrimidineTractVariant,  Consequence::IntronVariant]
+    )] // -5bp intronic
+    #[case("3:193332506:T:C", -6, vec![Consequence::SpliceRegionVariant, Consequence::SplicePolypyrimidineTractVariant, Consequence::IntronVariant]
+    )] // -6bp intronic
+    #[case("3:193332505:C:G", -7, vec![Consequence::SpliceRegionVariant, Consequence::SplicePolypyrimidineTractVariant, Consequence::IntronVariant]
+    )] // -7bp intronic
+    #[case("3:193332504:T:C", -8, vec![Consequence::SpliceRegionVariant, Consequence::SplicePolypyrimidineTractVariant, Consequence::IntronVariant]
+    )] // -8bp intronic
+    #[case("3:193332503:T:A", -9, vec![Consequence::SplicePolypyrimidineTractVariant, Consequence::IntronVariant]
+    )] // -9bp intronic
+    #[case("3:193332831:G:T", 1, vec![Consequence::SpliceDonorVariant, Consequence::IntronVariant]
+    )] // 1bp intronic
+    #[case("3:193332832:T:C", 2, vec![Consequence::SpliceDonorVariant, Consequence::IntronVariant]
+    )] // 2bp intronic
+    #[case("3:193332833:G:A", 3, vec![Consequence::SpliceRegionVariant, Consequence::SpliceDonorRegionVariant, Consequence::IntronVariant]
+    )] // 3bp intronic
+    #[case("3:193332834:A:C", 4, vec![Consequence::SpliceRegionVariant, Consequence::SpliceDonorRegionVariant, Consequence::IntronVariant]
+    )] // 4bp intronic
+    #[case("3:193332835:A:T", 5, vec![Consequence::SpliceDonorFifthBaseVariant, Consequence::SpliceRegionVariant, Consequence::SpliceDonorRegionVariant, Consequence::IntronVariant]
+    )] // 5bp intronic
+    #[case("3:193332836:C:A", 6, vec![Consequence::SpliceRegionVariant, Consequence::SpliceDonorRegionVariant, Consequence::IntronVariant]
+    )] // 6bp intronic
+    #[case("3:193332837:T:G", 7, vec![Consequence::SpliceRegionVariant, Consequence::IntronVariant]
+    )] // 7bp intronic
+    #[case("3:193332838:T:G", 8, vec![Consequence::SpliceRegionVariant, Consequence::IntronVariant]
+    )] // 8bp intronic
     #[case("3:193332839:G:A", 9, vec![Consequence::IntronVariant])] // 9bp intronic
     #[case("3:193332846:A:G", 16, vec![Consequence::IntronVariant])] // 16bp intronic
     #[case("3:193332847:G:A", 17, vec![Consequence::IntronVariant])] // 17bp intronic

--- a/src/annotate/seqvars/snapshots/mehari__annotate__seqvars__csq__test__annotate_del_opa1_csqs@3-193311167-ATGT-T.snap
+++ b/src/annotate/seqvars/snapshots/mehari__annotate__seqvars__csq__test__annotate_del_opa1_csqs@3-193311167-ATGT-T.snap
@@ -1,0 +1,34 @@
+---
+source: src/annotate/seqvars/csq.rs
+expression: res
+---
+- allele:
+    Alt:
+      alternative: T
+  consequences:
+    - start_lost
+  putative_impact: HIGH
+  gene_symbol: OPA1
+  gene_id: "HGNC:8140"
+  feature_type:
+    SoTerm:
+      term: Transcript
+  feature_id: NM_130837.3
+  feature_biotype:
+    - Coding
+    - ManeSelect
+  rank:
+    ord: 1
+    total: 31
+  hgvs_t: c.1_3del
+  hgvs_p: p.Met1?
+  tx_pos:
+    ord: 171
+    total: 6429
+  cds_pos:
+    ord: 1
+    total: 3048
+  protein_pos: ~
+  distance: 0
+  strand: 1
+  messages: ~

--- a/src/annotate/seqvars/snapshots/mehari__annotate__seqvars__csq__test__annotate_del_opa1_csqs@3-193311170-TGGC-C.snap
+++ b/src/annotate/seqvars/snapshots/mehari__annotate__seqvars__csq__test__annotate_del_opa1_csqs@3-193311170-TGGC-C.snap
@@ -1,0 +1,36 @@
+---
+source: src/annotate/seqvars/csq.rs
+expression: res
+---
+- allele:
+    Alt:
+      alternative: C
+  consequences:
+    - conservative_inframe_deletion
+  putative_impact: MODERATE
+  gene_symbol: OPA1
+  gene_id: "HGNC:8140"
+  feature_type:
+    SoTerm:
+      term: Transcript
+  feature_id: NM_130837.3
+  feature_biotype:
+    - Coding
+    - ManeSelect
+  rank:
+    ord: 1
+    total: 31
+  hgvs_t: c.4_6del
+  hgvs_p: p.Trp2del
+  tx_pos:
+    ord: 174
+    total: 6429
+  cds_pos:
+    ord: 4
+    total: 3048
+  protein_pos:
+    ord: 2
+    total: 1016
+  distance: 0
+  strand: 1
+  messages: ~

--- a/src/annotate/seqvars/snapshots/mehari__annotate__seqvars__csq__test__annotate_del_opa1_csqs@3-193311170-TGGCG-G.snap
+++ b/src/annotate/seqvars/snapshots/mehari__annotate__seqvars__csq__test__annotate_del_opa1_csqs@3-193311170-TGGCG-G.snap
@@ -1,0 +1,36 @@
+---
+source: src/annotate/seqvars/csq.rs
+expression: res
+---
+- allele:
+    Alt:
+      alternative: G
+  consequences:
+    - frameshift_variant
+  putative_impact: HIGH
+  gene_symbol: OPA1
+  gene_id: "HGNC:8140"
+  feature_type:
+    SoTerm:
+      term: Transcript
+  feature_id: NM_130837.3
+  feature_biotype:
+    - Coding
+    - ManeSelect
+  rank:
+    ord: 1
+    total: 31
+  hgvs_t: c.4_7del
+  hgvs_p: p.Trp2AspfsTer15
+  tx_pos:
+    ord: 174
+    total: 6429
+  cds_pos:
+    ord: 4
+    total: 3048
+  protein_pos:
+    ord: 2
+    total: 1016
+  distance: 0
+  strand: 1
+  messages: ~

--- a/src/annotate/seqvars/snapshots/mehari__annotate__seqvars__csq__test__annotate_del_opa1_csqs@3-193311180-GTCG-G.snap
+++ b/src/annotate/seqvars/snapshots/mehari__annotate__seqvars__csq__test__annotate_del_opa1_csqs@3-193311180-GTCG-G.snap
@@ -1,0 +1,36 @@
+---
+source: src/annotate/seqvars/csq.rs
+expression: res
+---
+- allele:
+    Alt:
+      alternative: G
+  consequences:
+    - disruptive_inframe_deletion
+  putative_impact: MODERATE
+  gene_symbol: OPA1
+  gene_id: "HGNC:8140"
+  feature_type:
+    SoTerm:
+      term: Transcript
+  feature_id: NM_130837.3
+  feature_biotype:
+    - Coding
+    - ManeSelect
+  rank:
+    ord: 1
+    total: 31
+  hgvs_t: c.15_17del
+  hgvs_p: p.Arg6del
+  tx_pos:
+    ord: 185
+    total: 6429
+  cds_pos:
+    ord: 15
+    total: 3048
+  protein_pos:
+    ord: 6
+    total: 1016
+  distance: 0
+  strand: 1
+  messages: ~

--- a/src/annotate/seqvars/snapshots/mehari__annotate__seqvars__csq__test__annotate_del_opa1_csqs@3-193409910-GAAA-G.snap
+++ b/src/annotate/seqvars/snapshots/mehari__annotate__seqvars__csq__test__annotate_del_opa1_csqs@3-193409910-GAAA-G.snap
@@ -1,0 +1,36 @@
+---
+source: src/annotate/seqvars/csq.rs
+expression: res
+---
+- allele:
+    Alt:
+      alternative: G
+  consequences:
+    - conservative_inframe_deletion
+  putative_impact: MODERATE
+  gene_symbol: OPA1
+  gene_id: "HGNC:8140"
+  feature_type:
+    SoTerm:
+      term: Transcript
+  feature_id: NM_130837.3
+  feature_biotype:
+    - Coding
+    - ManeSelect
+  rank:
+    ord: 30
+    total: 31
+  hgvs_t: c.3043_3045del
+  hgvs_p: p.Lys1015Ter
+  tx_pos:
+    ord: 3213
+    total: 6429
+  cds_pos:
+    ord: 3043
+    total: 3048
+  protein_pos:
+    ord: 1015
+    total: 1016
+  distance: 0
+  strand: 1
+  messages: ~

--- a/src/annotate/seqvars/snapshots/mehari__annotate__seqvars__csq__test__annotate_del_opa1_csqs@3-193409913-ATAA-A.snap
+++ b/src/annotate/seqvars/snapshots/mehari__annotate__seqvars__csq__test__annotate_del_opa1_csqs@3-193409913-ATAA-A.snap
@@ -1,0 +1,37 @@
+---
+source: src/annotate/seqvars/csq.rs
+expression: res
+---
+- allele:
+    Alt:
+      alternative: A
+  consequences:
+    - stop_lost
+    - feature_elongation
+  putative_impact: HIGH
+  gene_symbol: OPA1
+  gene_id: "HGNC:8140"
+  feature_type:
+    SoTerm:
+      term: Transcript
+  feature_id: NM_130837.3
+  feature_biotype:
+    - Coding
+    - ManeSelect
+  rank:
+    ord: 30
+    total: 31
+  hgvs_t: c.3046_3048del
+  hgvs_p: p.Ter1016IleextTer12
+  tx_pos:
+    ord: 3216
+    total: 6429
+  cds_pos:
+    ord: 3046
+    total: 3048
+  protein_pos:
+    ord: 1016
+    total: 1016
+  distance: 0
+  strand: 1
+  messages: ~


### PR DESCRIPTION
This also changes the way `conservative` is determined; ~I am not sure whether the end position is in- or exclusive at that point, i.e. if the change here is correct or not.~
*Edit*: should indeed be `end_base + 1`