### PR TITLE
feat: Add catch all tag "Other"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ enumflags2 = { version = "0.7.10", features = ["serde"] }
 env_logger = "0.11"
 flate2 = "1.0"
 futures = "0.3"
-hgvs = "0.17.2"
+hgvs = "0.17.3"
 indexmap = { version = "2.5", features = ["serde"] }
 indicatif = { version = "0.17", features = ["rayon"] }
 itertools = "0.13"

--- a/protos/mehari/txs.proto
+++ b/protos/mehari/txs.proto
@@ -65,6 +65,8 @@ enum TranscriptTag {
     TRANSCRIPT_TAG_SELENOPROTEIN = 6;
     // Member of GENCODE Primary
     TRANSCRIPT_TAG_GENCODE_PRIMARY = 7;
+    // catchall for other tags
+    TRANSCRIPT_TAG_OTHER = 8;
 }
 
 // Store information about a transcript.

--- a/src/annotate/seqvars/provider.rs
+++ b/src/annotate/seqvars/provider.rs
@@ -228,7 +228,7 @@ impl Provider {
                                     .iter()
                                     .filter_map(|tag| {
                                         match TranscriptTag::try_from(*tag).unwrap() {
-                                            TranscriptTag::Unknown => None,
+                                            TranscriptTag::Unknown | TranscriptTag::Other => None,
                                             TranscriptTag::Basic => Some(TranscriptPickType::Basic),
                                             TranscriptTag::EnsemblCanonical => {
                                                 Some(TranscriptPickType::EnsemblCanonical)

--- a/src/db/create/mod.rs
+++ b/src/db/create/mod.rs
@@ -1380,6 +1380,7 @@ impl TranscriptLoader {
                     }
                     Tag::RefSeqSelect => crate::pbs::txs::TranscriptTag::RefSeqSelect.into(),
                     Tag::GencodePrimary => crate::pbs::txs::TranscriptTag::GencodePrimary.into(),
+                    Tag::Other => crate::pbs::txs::TranscriptTag::Other.into(),
                 };
                 tags.insert(elem);
             }


### PR DESCRIPTION
This adds a transcript tag variant "Other" for any tag that is not accounted for currently or with respect to future cdot changes.
See also https://github.com/varfish-org/hgvs-rs/pull/204