### PR TITLE
fix: skip REF-only records

### DIFF
--- a/src/annotate/strucvars/mod.rs
+++ b/src/annotate/strucvars/mod.rs
@@ -2963,7 +2963,7 @@ pub async fn run_vcf_to_jsonl(
             || record.alternate_bases().as_ref() == &["<*>".to_string()]
         {
             // REF-only, skip
-            tracing::warn!("skipping REF-only record {:?}", record);
+            tracing::warn!("skipping REF-only / empty ALT record {:?}", record);
             continue;
         }
         let mut record = converter.convert(pedigree, &record, uuid, GenomeRelease::Grch37)?;

--- a/src/annotate/strucvars/mod.rs
+++ b/src/annotate/strucvars/mod.rs
@@ -2959,9 +2959,11 @@ pub async fn run_vcf_to_jsonl(
         rng.fill_bytes(&mut uuid_buf);
         let uuid = Uuid::from_bytes(uuid_buf);
 
-        if record.alternate_bases().is_empty() {
+        if record.alternate_bases().is_empty()
+            || record.alternate_bases().as_ref() == &["<*>".to_string()]
+        {
             // REF-only, skip
-            tracing::warn!("skipping REF-only record {:?}", record,);
+            tracing::warn!("skipping REF-only record {:?}", record);
             continue;
         }
         let mut record = converter.convert(pedigree, &record, uuid, GenomeRelease::Grch37)?;

--- a/src/annotate/strucvars/mod.rs
+++ b/src/annotate/strucvars/mod.rs
@@ -1889,7 +1889,7 @@ pub trait VcfRecordConverter {
         let mut end: Option<i32> = None;
         let alleles = vcf_record.alternate_bases().as_ref();
         if alleles.len() != 1 {
-            panic!("Only one alternative allele is supported for SVs");
+            panic!("Only one alternative allele is supported for SVs, got {} alternative alleles ({:?})", alleles.len(), alleles);
         }
         let allele = &alleles[0];
         // TODO find out how to handle this properly (via noodles?)
@@ -2959,6 +2959,11 @@ pub async fn run_vcf_to_jsonl(
         rng.fill_bytes(&mut uuid_buf);
         let uuid = Uuid::from_bytes(uuid_buf);
 
+        if record.alternate_bases().is_empty() {
+            // REF-only, skip
+            tracing::warn!("skipping REF-only record {:?}", record,);
+            continue;
+        }
         let mut record = converter.convert(pedigree, &record, uuid, GenomeRelease::Grch37)?;
         annotate_cov_mq(&mut record, cov_readers)?;
         if let Some(chromosome_no) = mapping.get(&record.chromosome) {

--- a/src/annotate/strucvars/mod.rs
+++ b/src/annotate/strucvars/mod.rs
@@ -2960,7 +2960,7 @@ pub async fn run_vcf_to_jsonl(
         let uuid = Uuid::from_bytes(uuid_buf);
 
         if record.alternate_bases().is_empty()
-            || record.alternate_bases().as_ref() == &["<*>".to_string()]
+            || record.alternate_bases().as_ref() == ["<*>".to_string()]
         {
             // REF-only, skip
             tracing::warn!("skipping REF-only / empty ALT record {:?}", record);


### PR DESCRIPTION
Skip REF-only (no alternative alleles) records

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling with checks for REF-only records and empty alternate bases.
	- Introduced coverage annotation functionality for structural variant records.
	- Improved UUID generation for deterministic outputs.
	- Enhanced clustering logic for accurate grouping of SV records.
	- Modularized record conversion for improved maintainability.

- **Bug Fixes**
	- Adjusted record processing to skip empty alternate bases and REF-only records.

- **Tests**
	- Expanded test suite to cover additional scenarios and SV callers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->