### PR TITLE
feat: Add rare amino acid SO term

### DIFF
--- a/openapi.schema.yaml
+++ b/openapi.schema.yaml
@@ -7,7 +7,7 @@ info:
     email: manuel.holtgrewe@bih-charite.de
   license:
     name: MIT
-  version: 0.30.0
+  version: 0.30.1
 paths:
   /api/v1/genes/transcripts:
     get:
@@ -218,6 +218,7 @@ components:
       - conservative_inframe_insertion
       - conservative_inframe_deletion
       - missense_variant
+      - rare_amino_acid_variant
       - splice_donor_5th_base_variant
       - splice_region_variant
       - splice_donor_region_variant

--- a/src/annotate/seqvars/ann.rs
+++ b/src/annotate/seqvars/ann.rs
@@ -263,7 +263,7 @@ pub enum Consequence {
     // SequenceVariant,
 
     /// "A transcript variant occurring within an intron."
-    /// SO:intron_variant
+    /// SO:intron_variant, VEP:intron_variant
     IntronVariant,
 
     /// "A sequence variant where the structure of the gene is changed."

--- a/src/annotate/seqvars/ann.rs
+++ b/src/annotate/seqvars/ann.rs
@@ -127,6 +127,10 @@ pub enum Consequence {
     /// SO:missense_variant, VEP:missense_variant
     MissenseVariant,
 
+    /// "A sequence variant whereby at least one base of a codon encoding a rare amino acid is changed, resulting in a different encoded amino acid."
+    /// SO:rare_amino_acid_variant
+    RareAminoAcidVariant,
+
     // Not used by mehari, but by VEP (we're usually more specific)
     // /// "A sequence_variant which is predicted to change the protein encoded in the coding sequence."
     // /// SO:protein_altering_variant, VEP:missense_variant
@@ -261,7 +265,6 @@ pub enum Consequence {
     // /// "A sequence_variant is a non exact copy of a sequence_feature or genome exhibiting one or more sequence_alteration."
     // /// SO:sequence_variant, VEP:sequence_variant
     // SequenceVariant,
-
     /// "A transcript variant occurring within an intron."
     /// SO:intron_variant, VEP:intron_variant
     IntronVariant,
@@ -290,7 +293,8 @@ impl From<Consequence> for PutativeImpact {
             | DisruptiveInframeDeletion
             | ConservativeInframeInsertion
             | ConservativeInframeDeletion
-            | MissenseVariant => PutativeImpact::Moderate,
+            | MissenseVariant
+            | RareAminoAcidVariant => PutativeImpact::Moderate,
             SpliceDonorFifthBaseVariant
             | SpliceRegionVariant
             | SpliceDonorRegionVariant

--- a/src/annotate/seqvars/ann.rs
+++ b/src/annotate/seqvars/ann.rs
@@ -261,6 +261,9 @@ pub enum Consequence {
     // /// "A sequence_variant is a non exact copy of a sequence_feature or genome exhibiting one or more sequence_alteration."
     // /// SO:sequence_variant, VEP:sequence_variant
     // SequenceVariant,
+
+    /// "A transcript variant occurring within an intron."
+    /// SO:intron_variant
     IntronVariant,
 
     /// "A sequence variant where the structure of the gene is changed."

--- a/src/annotate/seqvars/csq.rs
+++ b/src/annotate/seqvars/csq.rs
@@ -1089,6 +1089,13 @@ impl ConsequencePredictor {
                                 }
                             } else {
                                 consequences |= Consequence::MissenseVariant;
+                                // Missense variants that affect selenocysteine are marked
+                                // as rare amino acid variants.
+                                if alternative.contains("U")
+                                    || (loc.start == loc.end) && loc.start.aa == "U"
+                                {
+                                    consequences |= Consequence::RareAminoAcidVariant;
+                                }
                             }
                         }
                         ProteinEdit::DelIns { alternative } => {


### PR DESCRIPTION
Missense variants affecting selenocysteine are reported as `rare_amino_acid_variant`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced variant consequence prediction to include:
		- Rare amino acid variant detection
		- Specific handling for selenocysteine-related variants
		- Expanded intron variant classification
		- New consequence type `rare_amino_acid_variant` in the API schema

- **Improvements**
	- Updated impact categorization for new variant types
	- Refined protein variant analysis logic
	- Incremented API version from `0.30.0` to `0.30.1`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->