### PR TITLE
fix: improve consequence predictions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,8 +1848,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hgvs"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e411f8beeb410413167d2ac7da7360f3ab9e3a8852c96688deb0495c811022"
+source = "git+https://github.com/varfish-org/hgvs-rs?branch=fix-ter-subst#afac6a3dee1eeb9062ba6de43390ddc8c747373a"
 dependencies = [
  "ahash 0.8.11",
  "base16ct",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,7 +1848,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hgvs"
 version = "0.18.0"
-source = "git+https://github.com/varfish-org/hgvs-rs?branch=fix-ter-subst#afac6a3dee1eeb9062ba6de43390ddc8c747373a"
 dependencies = [
  "ahash 0.8.11",
  "base16ct",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1847,7 +1847,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hgvs"
-version = "0.18.0"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897c9fa6e14f72b6099c29de4e7ac0247ca4917fb74eaa9d25358e1ae256b7e"
 dependencies = [
  "ahash 0.8.11",
  "base16ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ enumflags2 = { version = "0.7.11", features = ["serde"] }
 env_logger = "0.11"
 flate2 = "1.0"
 futures = "0.3"
-hgvs = { git = "https://github.com/varfish-org/hgvs-rs", branch = "fix-ter-subst" }
+hgvs = "0.18.1"
 indexmap = { version = "2.7", features = ["serde"] }
 itertools = "0.14"
 jsonl = "4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ enumflags2 = { version = "0.7.11", features = ["serde"] }
 env_logger = "0.11"
 flate2 = "1.0"
 futures = "0.3"
-hgvs = "0.18.0"
+hgvs = { git = "https://github.com/varfish-org/hgvs-rs", branch = "fix-ter-subst" }
 indexmap = { version = "2.7", features = ["serde"] }
 itertools = "0.14"
 jsonl = "4.0"

--- a/openapi.schema.yaml
+++ b/openapi.schema.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: MIT
     identifier: MIT
-  version: 0.30.1
+  version: 0.31.0
 paths:
   /api/v1/genes/transcripts:
     get:
@@ -412,6 +412,8 @@ components:
       - splice_donor_variant
       - stop_gained
       - frameshift_variant
+      - frameshift_elongation
+      - frameshift_truncation
       - stop_lost
       - start_lost
       - transcript_amplification
@@ -423,6 +425,7 @@ components:
       - conservative_inframe_deletion
       - missense_variant
       - rare_amino_acid_variant
+      - protein_altering_variant
       - splice_donor_5th_base_variant
       - splice_region_variant
       - splice_donor_region_variant

--- a/src/annotate/seqvars/ann.rs
+++ b/src/annotate/seqvars/ann.rs
@@ -85,7 +85,6 @@ pub enum Consequence {
     /// SO:frameshift_variant, VEP:frameshift_variant
     FrameshiftVariant,
 
-
     /// "A frameshift variant that causes the translational reading frame to be extended relative to the reference feature."
     /// SO:frameshift_elongation
     FrameshiftElongation,

--- a/src/annotate/seqvars/ann.rs
+++ b/src/annotate/seqvars/ann.rs
@@ -140,10 +140,9 @@ pub enum Consequence {
     /// SO:rare_amino_acid_variant
     RareAminoAcidVariant,
 
-    // Not used by mehari, but by VEP (we're usually more specific)
-    // /// "A sequence_variant which is predicted to change the protein encoded in the coding sequence."
-    // /// SO:protein_altering_variant, VEP:missense_variant
-    // ProteinAlteringVariant,
+    /// "A sequence_variant which is predicted to change the protein encoded in the coding sequence."
+    /// SO:protein_altering_variant, VEP:missense_variant
+    ProteinAlteringVariant,
 
     // low impact
     /// "A sequence variant that causes a change at the 5th base pair after the start of the intron in the orientation of the transcript."
@@ -304,6 +303,7 @@ impl From<Consequence> for PutativeImpact {
             | DisruptiveInframeDeletion
             | ConservativeInframeInsertion
             | ConservativeInframeDeletion
+            | ProteinAlteringVariant
             | MissenseVariant
             | RareAminoAcidVariant => PutativeImpact::Moderate,
             SpliceDonorFifthBaseVariant

--- a/src/annotate/seqvars/ann.rs
+++ b/src/annotate/seqvars/ann.rs
@@ -85,6 +85,15 @@ pub enum Consequence {
     /// SO:frameshift_variant, VEP:frameshift_variant
     FrameshiftVariant,
 
+
+    /// "A frameshift variant that causes the translational reading frame to be extended relative to the reference feature."
+    /// SO:frameshift_elongation
+    FrameshiftElongation,
+
+    /// "A frameshift variant that causes the translational reading frame to be shortened relative to the reference feature."
+    /// SO:frameshift_truncation
+    FrameshiftTruncation,
+
     /// "A sequence variant where at least one base of the terminator codon (stop) is changed, resulting in an elongated transcript."
     /// SO:stop_lost, VEP:stop_lost
     StopLost,
@@ -284,6 +293,8 @@ impl From<Consequence> for PutativeImpact {
             | SpliceDonorVariant
             | StopGained
             | FrameshiftVariant
+            | FrameshiftElongation
+            | FrameshiftTruncation
             | StopLost
             | StartLost
             | TranscriptAmplification

--- a/src/annotate/seqvars/csq.rs
+++ b/src/annotate/seqvars/csq.rs
@@ -1608,12 +1608,12 @@ mod test {
     }
 
     #[rstest::rstest]
-    #[case("3:193311167:ATGT:T", vec![Consequence::StartLost])]
+    #[case("3:193311167:ATGT:T", vec![Consequence::StartLost, Consequence::ConservativeInframeDeletion])]
     #[case("3:193311170:TGGC:C", vec![Consequence::ConservativeInframeDeletion])]
-    #[case("3:193311170:TGGCG:G", vec![Consequence::FrameshiftVariant])]
+    #[case("3:193311170:TGGCG:G", vec![Consequence::FrameshiftVariant, Consequence::ConservativeInframeDeletion])]
     #[case("3:193311180:GTCG:G", vec![Consequence::DisruptiveInframeDeletion])]
     #[case("3:193409910:GAAA:G", vec![Consequence::ConservativeInframeDeletion])]
-    #[case("3:193409913:ATAA:A", vec![Consequence::StopLost, Consequence::FeatureElongation])]
+    #[case("3:193409913:ATAA:A", vec![Consequence::StopLost, Consequence::FeatureElongation, Consequence::ConservativeInframeDeletion])]
     fn annotate_del_opa1_csqs(
         #[case] spdi: &str,
         #[case] expected_csqs: Vec<Consequence>,

--- a/src/annotate/seqvars/csq.rs
+++ b/src/annotate/seqvars/csq.rs
@@ -1080,6 +1080,7 @@ impl ConsequencePredictor {
                             }
                         }
                         ProteinEdit::DelIns { alternative } => {
+                            consequences |= Consequence::ProteinAlteringVariant;
                             match alternative
                                 .len()
                                 .cmp(&(loc.start.number.abs_diff(loc.end.number) as usize + 1))
@@ -1095,6 +1096,7 @@ impl ConsequencePredictor {
                                     // it is a missense variant, not an inframe deletion
                                     // cf https://github.com/Ensembl/ensembl-vep/issues/1388
                                     consequences |= Consequence::MissenseVariant;
+                                    consequences &= !Consequence::ProteinAlteringVariant;
                                 }
                                 Ordering::Greater if conservative => {
                                     consequences |= Consequence::ConservativeInframeInsertion;

--- a/src/annotate/seqvars/csq.rs
+++ b/src/annotate/seqvars/csq.rs
@@ -1998,7 +1998,14 @@ mod test {
             lineno += 1;
 
             let record: Record = record?;
-            // let mut printed = false;
+
+            // Because for this variant our highest impact is "HIGH" and vep's is not (and because we filter for the highest impact), skip it.
+            // We predict FrameshiftVariant, FrameshiftTruncation, SpliceRegionVariant and ThreePrimeUtrExonVariant,
+            // while vep calls "splice_region_variant", "coding_sequence_variant", "3_prime_UTR_variant".
+            if record.var == "17-41196310-GGTGGAAGTGTTTGCTACCAAGTTTATTTGCAGTGTTAACAGCACAACATTTACAAAACGTATTTTGTACAATCAAGTCTTCACTGCCCTTGCACACTGGGGGGGCTAGGGAAGACCTAGTCCTTCCAACAGCTATAAACAGTCCTGGATAATGGGTTTATGAAAAACACTTTTTCTTCCTTCAGCAAGCAAAATTATTTATGAAGCTGTATGGTTTCAGCAACAGGGAGCAAAGGAAAAAAATCACCTCAAAGAAAGCAACAGCTTCCTTCCTGGTGGGATCTGTCATTTTATAGATATGAAATATTCATGCCAGAGGTCTTATATTTTAAGAGGAATGGATTATATACCAGAGCTACAACAATAAACATTTTACTTATTACTAATGAGGAATTAGAAGACTGTCTTTGGAAACCGGTTCTTGAAAATCTTCTGCTGTTTTAGAACACATTCTTTAGAAATCTAGCAAATATATCTCAGACTTTTAGAAATCTCTTCTAGTTTCATTTTCCTTTTTTTTTTTTTTTTTTTGAGCCACAGTCTCACTGTCACCCAGGCTGGAGTGCCGTGGTATGATCTTGGCTCACTGCAACCTCCACCTCCCGGGCTGAAGTGATTCTCCTGCCTTAGCCACCTGAGTAGCTGGGATTACAGGTGTCCACCACCATGACCGGCTAATTTCTGTATTTTTAGTAGAGATGGGGTTTCACCATGTTGGCCAGGCTGGTTTCGAACTCCTGACCTCCAGTGATCTGCCCACCTTGGCCTCCCAAAGTGCTGGGATTACAGGCGTGAGCCACCATGCCCAGGTTTCAAGTTTCCTTTTCATTTCTAATACCTGCCTCAGAATTTCCTCCCCAATGTTCCACTCCAACATTTGAGAACTGCCCAAGGACTATTCTGACTTTAAGTCACATAATCGATCCCAAGCACTCTCCTTCCATTGAAGGGTCTGACTCTCTGCCTTTGTGAACACAGGGTTTTAGAGAAGTAAACTTAGGGAAACCAGCTATTCTCTTGAGGCCAAGCCACTCTGTGCTTCCAGCCCTAAGCCAACAACAGCCTGAATAGAAAGAATAGGGCTGATAAATAATGAATCAGCATCTTGCTCAATTGGTGGCGTTTAAATGGTTTTAAAATCTTCTCAGGTGAAAAATTACCATAATTTTGTGCTCATGGCAGATTTCCAAGGGAGACTTCAAGCAGAAAATCTTTAAGGGACCCTTGCATAGCCAGAAGTCCTTTTCAGGCTGATGTACATAAAATATTTAGTAGCCAGGACAGTAGAAGGACTGAAGAGTGAGAGGAGCTCCCAGGGCCTGGAAAGGCCACTTTGTAAGCTCATTCTTGGGGTCCTGTGGCTCTGTACCTGTGGCTGGCTGCAGTCAGTAGTGGCTGTGGGGGATCTGGGGTATCAGGTAGGTGTCCAGCTCCTGGCACTGGTAGAGTGCTACACTGTCCAACACCCACTCTCGGGTCACCACAGGTGCCTCACACATCTGCCCAATT-G" {
+                continue;
+            }
+
             if txs.contains(&record.tx) {
                 // "Parse" out the variant.
                 let arr = record.var.split('-').collect::<Vec<_>>();
@@ -2038,89 +2045,83 @@ mod test {
                         expected_one_of.push("inframe_deletion");
                     }
 
-                    // Try to find a direct match.
-                    let found_one = record_csqs.iter().any(|csq| expected_one_of.contains(csq));
-
-                    // vep sometimes only reports a coding_sequence_variant, so we accept anything
-                    let found_one = found_one
-                        || path_tsv.contains(".vep")
+                    let found_one = [
+                        // Try to find a direct match.
+                        record_csqs.iter().any(|csq| expected_one_of.contains(csq)),
+                        // vep sometimes only reports a coding_sequence_variant, so we accept anything
+                        path_tsv.contains(".vep")
                             && (record_csqs == ["coding_sequence_variant"]
-                                && !expected_one_of.is_empty());
-
-                    // It is common that the other tool predicts a frameshift variant while the actual prediction
-                    // is stop_gained or stop_lost.  We thus also check for this case and allow it.
-                    let found_one = found_one
-                        || (record_csqs.contains(&"frameshift_variant")
+                                && !expected_one_of.is_empty()),
+                        // It is common that the other tool predicts a frameshift variant while the actual prediction
+                        // is stop_gained or stop_lost.  We thus also check for this case and allow it.
+                        (record_csqs.contains(&"frameshift_variant")
+                            || record_csqs.contains(&"frameshift_truncation")
+                            || record_csqs.contains(&"frameshift_elongation"))
                             && (expected_one_of.contains(&"stop_gained"))
-                            || expected_one_of.contains(&"stop_lost"));
-                    // VEP does not differentiate between disruptive and conservative inframe deletions and insertions.
-                    let found_one = found_one
-                        || (record_csqs.contains(&"inframe_deletion")
+                            || expected_one_of.contains(&"stop_lost"),
+                        // … or vice-versa
+                        (expected_one_of.contains(&"frameshift_variant")
+                            || expected_one_of.contains(&"frameshift_truncation")
+                            || expected_one_of.contains(&"frameshift_elongation"))
+                            && (record_csqs.contains(&"stop_gained"))
+                            || record_csqs.contains(&"stop_lost"),
+                        // VEP does not differentiate between disruptive and conservative inframe deletions and insertions.
+                        (record_csqs.contains(&"inframe_deletion")
                             && (expected_one_of.contains(&"disruptive_inframe_deletion")
                                 || expected_one_of.contains(&"conservative_inframe_deletion")))
-                        || (record_csqs.contains(&"inframe_insertion")
-                            && (expected_one_of.contains(&"disruptive_inframe_insertion")
-                                || expected_one_of.contains(&"conservative_inframe_insertion")));
-                    // NB: We cannot predict 5_prime_UTR_premature_start_codon_gain_variant yet. For now, we
-                    // also accept 5_prime_UTR_variant.
-                    let found_one = found_one
-                        || ((expected_one_of.contains(&"5_prime_UTR_exon_variant")
+                            || (record_csqs.contains(&"inframe_insertion")
+                                && (expected_one_of.contains(&"disruptive_inframe_insertion")
+                                    || expected_one_of
+                                        .contains(&"conservative_inframe_insertion"))),
+                        // NB: We cannot predict 5_prime_UTR_premature_start_codon_gain_variant yet. For now, we
+                        // also accept 5_prime_UTR_variant.
+                        ((expected_one_of.contains(&"5_prime_UTR_exon_variant")
                             || expected_one_of.contains(&"5_prime_UTR_intron_variant"))
                             && (record_csqs
-                                .contains(&"5_prime_UTR_premature_start_codon_gain_variant")));
-                    // VEP predicts `splice_donor_5th_base_variant` rather than `splice_region_variant`.
-                    // Same for `splice_donor_region_variant`.
-                    let found_one = found_one
-                        || (expected_one_of.contains(&"splice_region_variant")
+                                .contains(&"5_prime_UTR_premature_start_codon_gain_variant"))),
+                        // VEP predicts `splice_donor_5th_base_variant` rather than `splice_region_variant`.
+                        // Same for `splice_donor_region_variant`.
+                        (expected_one_of.contains(&"splice_region_variant")
                             && (record_csqs.contains(&"splice_donor_5th_base_variant")
-                                || record_csqs.contains(&"splice_donor_region_variant")));
-                    // In the case of insertions at the end of an exon, VEP predicts `splice_region_variant`
-                    // while we predict `splice_donor_variant`, same for start.
-                    let found_one = found_one
-                        || (expected_one_of.contains(&"splice_donor_variant")
+                                || record_csqs.contains(&"splice_donor_region_variant"))),
+                        // In the case of insertions at the end of an exon, VEP predicts `splice_region_variant`
+                        // while we predict `splice_donor_variant`, same for start.
+                        (expected_one_of.contains(&"splice_donor_variant")
                             || expected_one_of.contains(&"splice_acceptor_variant"))
-                            && (record_csqs.contains(&"splice_region_variant"));
-                    // VEP sometimes mispredicts disruptive inframe deletion as missense...
-                    // cf. https://github.com/Ensembl/ensembl-vep/issues/1388
-                    let found_one = found_one
-                        || expected_one_of.contains(&"disruptive_inframe_deletion")
-                            && (record_csqs.contains(&"missense_variant"));
-                    // VEP does not provide `exon_loss_variant`, so we also accept `inframe_deletion` and
-                    // `splice_region_variant` (BRA1 test case).
-                    let found_one = found_one
-                        || expected_one_of.contains(&"exon_loss_variant")
+                            && (record_csqs.contains(&"splice_region_variant")),
+                        // VEP sometimes mispredicts disruptive inframe deletion as missense...
+                        // cf. https://github.com/Ensembl/ensembl-vep/issues/1388
+                        expected_one_of.contains(&"disruptive_inframe_deletion")
+                            && (record_csqs.contains(&"missense_variant")),
+                        // VEP does not provide `exon_loss_variant`, so we also accept `inframe_deletion` and
+                        // `splice_region_variant` (BRA1 test case).
+                        expected_one_of.contains(&"exon_loss_variant")
                             && (record_csqs.contains(&"inframe_deletion")
-                                || record_csqs.contains(&"splice_region_variant"));
-                    // On BRCA1, there is a case where VEP predicts `protein_altering_variant` rather than
-                    // `disruptive_inframe_deletion`.  We accept this as well.
-                    let found_one = found_one
-                        || (expected_one_of.contains(&"disruptive_inframe_deletion")
+                                || record_csqs.contains(&"splice_region_variant")),
+                        // On BRCA1, there is a case where VEP predicts `protein_altering_variant` rather than
+                        // `disruptive_inframe_deletion`.  We accept this as well.
+                        (expected_one_of.contains(&"disruptive_inframe_deletion")
                             || expected_one_of.contains(&"inframe_indel"))
-                            && (record_csqs.contains(&"protein_altering_variant"));
-                    // In the case of `GRCh37:17:41258543:T:TA`, the `hgvs` prediction is `c.-1_1insT` and
-                    // `p.Met1?` which leads to `start_lost` while VEP predicts `5_prime_UTR_variant`.
-                    // This may be a bug in `hgvs` and we don't change this for now.  We accept the call
-                    // by VEP, of course.
-                    let found_one = found_one
-                        || expected_one_of.contains(&"start_lost")
-                            && (record_csqs.contains(&"5_prime_UTR_variant"));
-                    // We have specialized {5,3}_prime_UTR_{exon,intron}_variant handling, while
-                    // vep and snpEff do not
-                    let found_one = found_one
-                        || record_csqs.contains(&"5_prime_UTR_variant")
+                            && (record_csqs.contains(&"protein_altering_variant")),
+                        // In the case of `GRCh37:17:41258543:T:TA`, the `hgvs` prediction is `c.-1_1insT` and
+                        // `p.Met1?` which leads to `start_lost` while VEP predicts `5_prime_UTR_variant`.
+                        // This may be a bug in `hgvs` and we don't change this for now.  We accept the call
+                        // by VEP, of course.
+                        expected_one_of.contains(&"start_lost")
+                            && (record_csqs.contains(&"5_prime_UTR_variant")),
+                        // We have specialized {5,3}_prime_UTR_{exon,intron}_variant handling, while
+                        // vep and snpEff do not
+                        record_csqs.contains(&"5_prime_UTR_variant")
                             && (expected_one_of.contains(&"5_prime_UTR_exon_variant")
-                                || expected_one_of.contains(&"5_prime_UTR_intron_variant"));
-                    let found_one = found_one
-                        || record_csqs.contains(&"3_prime_UTR_variant")
+                                || expected_one_of.contains(&"5_prime_UTR_intron_variant")),
+                        record_csqs.contains(&"3_prime_UTR_variant")
                             && (expected_one_of.contains(&"3_prime_UTR_exon_variant")
-                                || expected_one_of.contains(&"3_prime_UTR_intron_variant"));
-                    // an inframe_indel can be a missense_variant if it is an MNV (which we do not explicitly check here)
-                    let found_one = found_one
-                        || expected_one_of.contains(&"inframe_indel")
-                            && (record_csqs.contains(&"missense_variant"));
-                    // inframe_indel also is a superclass of *_inframe_{deletion, insertion}
-                    let found_one = found_one
-                        || expected_one_of.contains(&"inframe_indel")
+                                || expected_one_of.contains(&"3_prime_UTR_intron_variant")),
+                        // an inframe_indel can be a missense_variant if it is an MNV (which we do not explicitly check here)
+                        expected_one_of.contains(&"inframe_indel")
+                            && (record_csqs.contains(&"missense_variant")),
+                        // inframe_indel also is a superclass of *_inframe_{deletion, insertion}
+                        expected_one_of.contains(&"inframe_indel")
                             && [
                                 "disruptive_inframe_deletion",
                                 "conservative_inframe_deletion",
@@ -2130,42 +2131,38 @@ mod test {
                                 "inframe_insertion",
                             ]
                             .iter()
-                            .any(|c| record_csqs.contains(c));
-                    // SnpEff has a different interpretation of disruptive/conservative inframe deletions.
-                    // We thus allow both.
-                    let found_one = found_one
-                        || expected_one_of.contains(&"disruptive_inframe_deletion")
+                            .any(|c| record_csqs.contains(c)),
+                        // SnpEff has a different interpretation of disruptive/conservative inframe deletions.
+                        // We thus allow both.
+                        expected_one_of.contains(&"disruptive_inframe_deletion")
                             && (record_csqs.contains(&"conservative_inframe_deletion"))
-                        || expected_one_of.contains(&"disruptive_inframe_insertion")
-                            && (record_csqs.contains(&"conservative_inframe_insertion"));
-                    // SnpEff may not predict `splice_region_variant` for 5' UTR correctly, so we
-                    // allow this.
-                    let found_one = found_one
-                        || expected_one_of.contains(&"splice_region_variant")
-                            && (record_csqs.contains(&"5_prime_UTR_variant"));
-                    // SnpEff does not predict `splice_polypyrimidine_tract_variant`
-                    let found_one = found_one
-                        || expected_one_of.contains(&"splice_polypyrimidine_tract_variant")
+                            || expected_one_of.contains(&"disruptive_inframe_insertion")
+                                && (record_csqs.contains(&"conservative_inframe_insertion")),
+                        // SnpEff may not predict `splice_region_variant` for 5' UTR correctly, so we
+                        // allow this.
+                        expected_one_of.contains(&"splice_region_variant")
+                            && (record_csqs.contains(&"5_prime_UTR_variant")),
+                        // SnpEff does not predict `splice_polypyrimidine_tract_variant`
+                        expected_one_of.contains(&"splice_polypyrimidine_tract_variant")
                             && (record_csqs.contains(&"splice_region_variant")
-                                || record_csqs.contains(&"intron_variant"));
-                    // For `GRCh37:3:193366573:A:ATATTGCCTAGAATGAACT`, SnpEff predicts
-                    // `stop_gained` while this rather is a intron variant.  We skip this variant.
-                    let found_one = found_one
-                        || record_csqs.contains(&"stop_gained")
-                            && record.var == "3-193366573-A-ATATTGCCTAGAATGAACT";
-                    // For `GRCh37:3:193409913:ATAAAT:A`, there appears to be a model error
-                    // in SnpEff as it predicts `exon_loss`.  We skip this variant.
-                    let found_one = found_one
-                        || record_csqs.contains(&"exon_loss_variant")
-                            && record.var == "3-193409913-ATAAAT-A";
-                    // SnpEff may predict `pMet1.?` as `initiator_codon_variant` rather than `start_lost`.
-                    let found_one = found_one
-                        || expected_one_of.contains(&"start_lost")
-                            && (record_csqs.contains(&"initiator_codon_variant"));
-                    // Similarly, SnpEff may predict `c.-1_1` as `start_retained` rather than `start_lost`.
-                    let found_one = found_one
-                        || expected_one_of.contains(&"start_lost")
-                            && (record_csqs.contains(&"start_retained_variant"));
+                                || record_csqs.contains(&"intron_variant")),
+                        // For `GRCh37:3:193366573:A:ATATTGCCTAGAATGAACT`, SnpEff predicts
+                        // `stop_gained` while this rather is a intron variant.  We skip this variant.
+                        record_csqs.contains(&"stop_gained")
+                            && record.var == "3-193366573-A-ATATTGCCTAGAATGAACT",
+                        // For `GRCh37:3:193409913:ATAAAT:A`, there appears to be a model error
+                        // in SnpEff as it predicts `exon_loss`.  We skip this variant.
+                        record_csqs.contains(&"exon_loss_variant")
+                            && record.var == "3-193409913-ATAAAT-A",
+                        // SnpEff may predict `pMet1.?` as `initiator_codon_variant` rather than `start_lost`.
+                        expected_one_of.contains(&"start_lost")
+                            && (record_csqs.contains(&"initiator_codon_variant")),
+                        // Similarly, SnpEff may predict `c.-1_1` as `start_retained` rather than `start_lost`.
+                        expected_one_of.contains(&"start_lost")
+                            && (record_csqs.contains(&"start_retained_variant")),
+                    ]
+                    .iter()
+                    .any(|b| *b);
 
                     assert!(
                         found_one,

--- a/src/annotate/seqvars/csq.rs
+++ b/src/annotate/seqvars/csq.rs
@@ -1777,7 +1777,7 @@ mod test {
 
         let records_written = read_vcf(output).await?;
         let records_expected = read_vcf(expected_vcf).await?;
-        assert_eq!(records_written, records_expected);
+        assert_eq!(records_expected, records_written);
 
         Ok(())
     }

--- a/src/annotate/seqvars/csq.rs
+++ b/src/annotate/seqvars/csq.rs
@@ -933,7 +933,7 @@ impl ConsequencePredictor {
         var_c: &HgvsVariant,
         is_exonic: bool,
         is_intronic: bool,
-        _conservative: bool,
+        conservative: bool,
     ) -> Consequences {
         let mut consequences: Consequences = Consequences::empty();
 
@@ -942,7 +942,7 @@ impl ConsequencePredictor {
             // coordinates.  The cases where the start/stop codon is touched by the variant
             // directly is handled above based on the `var_p` prediction.
             let loc = loc_edit.loc.inner();
-            let _edit = loc_edit.edit.inner();
+            let edit = loc_edit.edit.inner();
             let start_base = loc.start.base;
             let start_cds_from = loc.start.cds_from;
             // let end_base = loc.end.base;
@@ -964,16 +964,15 @@ impl ConsequencePredictor {
             }
 
             // Detect variants affecting the 5'/3' UTRs.
-            if start_cds_from == CdsFrom::Start {
-                if start_base < 0 {
-                    if is_intronic {
-                        consequences |= Consequence::FivePrimeUtrIntronVariant;
-                    }
-                    if is_exonic {
-                        consequences |= Consequence::FivePrimeUtrExonVariant;
-                    }
+            if starts_left_of_start && start_base < 0 {
+                if is_intronic {
+                    consequences |= Consequence::FivePrimeUtrIntronVariant;
                 }
-            } else if end_cds_from == CdsFrom::End {
+                if is_exonic {
+                    consequences |= Consequence::FivePrimeUtrExonVariant;
+                }
+            }
+            if ends_right_of_stop {
                 if is_intronic {
                     consequences |= Consequence::ThreePrimeUtrIntronVariant;
                 }

--- a/src/annotate/seqvars/csq.rs
+++ b/src/annotate/seqvars/csq.rs
@@ -981,7 +981,7 @@ impl ConsequencePredictor {
                 }
             }
 
-            if !ends_right_of_stop && !starts_left_of_start {
+            if !ends_right_of_stop && !starts_left_of_start && (!is_intronic || is_exonic) {
                 match edit {
                     NaEdit::RefAlt {
                         reference,

--- a/src/annotate/seqvars/csq.rs
+++ b/src/annotate/seqvars/csq.rs
@@ -128,7 +128,14 @@ impl ConsequencePredictor {
     /// If there was any error during the prediction.
     pub fn predict(&self, var: &VcfVariant) -> Result<Option<Vec<AnnField>>, anyhow::Error> {
         // Normalize variant by stripping common prefix and suffix.
-        let norm_var = self.normalize_variant(var);
+        let mut norm_var = self.normalize_variant(var);
+
+        // TODO check for VCF specification version.
+        // According to VCF specification (>=4.1), an alternative of "N" means REF=ALT
+        // Prior to 4.1, it indicated a deletion.
+        if norm_var.alternative == "N" {
+            norm_var.alternative = norm_var.reference.clone();
+        }
 
         // Obtain accession from chromosome name.
         let chrom_acc = self.chrom_to_acc.get(&norm_var.chromosome);

--- a/src/annotate/seqvars/csq.rs
+++ b/src/annotate/seqvars/csq.rs
@@ -1169,6 +1169,12 @@ impl ConsequencePredictor {
                                 }
                             }
 
+                            if (is_stop(&loc.start.aa) || is_stop(&loc.end.aa))
+                                && !has_stop(alternative)
+                            {
+                                consequences |= Consequence::StopLost;
+                            }
+
                             if has_stop(alternative) {
                                 consequences |= Consequence::StopGained;
                             }

--- a/src/annotate/seqvars/csq.rs
+++ b/src/annotate/seqvars/csq.rs
@@ -1610,7 +1610,7 @@ mod test {
     #[rstest::rstest]
     #[case("3:193311167:ATGT:T", vec![Consequence::StartLost, Consequence::ConservativeInframeDeletion])]
     #[case("3:193311170:TGGC:C", vec![Consequence::ConservativeInframeDeletion])]
-    #[case("3:193311170:TGGCG:G", vec![Consequence::FrameshiftVariant, Consequence::ConservativeInframeDeletion])]
+    #[case("3:193311170:TGGCG:G", vec![Consequence::FrameshiftVariant, Consequence::FrameshiftTruncation])]
     #[case("3:193311180:GTCG:G", vec![Consequence::DisruptiveInframeDeletion])]
     #[case("3:193409910:GAAA:G", vec![Consequence::ConservativeInframeDeletion])]
     #[case("3:193409913:ATAA:A", vec![Consequence::StopLost, Consequence::FeatureElongation, Consequence::ConservativeInframeDeletion])]

--- a/src/annotate/seqvars/csq.rs
+++ b/src/annotate/seqvars/csq.rs
@@ -7,7 +7,7 @@ use crate::annotate::cli::{ConsequenceBy, TranscriptSource};
 use crate::pbs::txs::{GenomeAlignment, Strand, TranscriptBiotype, TranscriptTag};
 use enumflags2::BitFlags;
 use hgvs::mapper::altseq::AltSeqBuilder;
-use hgvs::parser::{NoRef, ProteinEdit, UncertainLengthChange};
+use hgvs::parser::{NoRef, ProteinEdit};
 use hgvs::{
     data::interface::{Provider, TxForRegionRecord},
     mapper::{assembly, Error},

--- a/src/annotate/seqvars/csq.rs
+++ b/src/annotate/seqvars/csq.rs
@@ -980,6 +980,47 @@ impl ConsequencePredictor {
                     consequences |= Consequence::ThreePrimeUtrExonVariant;
                 }
             }
+
+            if !ends_right_of_stop && !starts_left_of_start {
+                match edit {
+                    NaEdit::RefAlt {
+                        reference,
+                        alternative,
+                    } => {
+                        if reference.len().abs_diff(alternative.len()) % 3 != 0 {
+                            consequences |= Consequence::FrameshiftVariant;
+                        }
+                    }
+                    NaEdit::DelRef { reference } => {
+                        if reference.len() % 3 != 0 {
+                            consequences |= Consequence::FrameshiftVariant;
+                        } else if conservative {
+                            consequences |= Consequence::ConservativeInframeDeletion;
+                        } else {
+                            consequences |= Consequence::DisruptiveInframeDeletion;
+                        }
+                    }
+                    NaEdit::DelNum { count } => {
+                        if count % 3 != 0 {
+                            consequences |= Consequence::FrameshiftVariant;
+                        } else if conservative {
+                            consequences |= Consequence::ConservativeInframeDeletion;
+                        } else {
+                            consequences |= Consequence::DisruptiveInframeDeletion;
+                        }
+                    }
+                    NaEdit::Ins { alternative } => {
+                        if alternative.len() % 3 != 0 {
+                            consequences |= Consequence::FrameshiftVariant;
+                        } else if conservative {
+                            consequences |= Consequence::ConservativeInframeInsertion;
+                        } else {
+                            consequences |= Consequence::DisruptiveInframeInsertion;
+                        }
+                    }
+                    _ => {}
+                }
+            }
         } else {
             panic!("Must be CDS variant: {}", &var_c)
         };

--- a/src/annotate/seqvars/provider.rs
+++ b/src/annotate/seqvars/provider.rs
@@ -586,7 +586,9 @@ impl ProviderInterface for Provider {
                     .map_err(|_| Error::NoSequenceRecord(ac.to_string()))?
                     .ok_or_else(|| Error::NoSequenceRecord(ac.to_string()))?,
             };
-            return String::from_utf8(seq).map_err(|_| Error::NoSequenceRecord(chrom.to_string()));
+            return String::from_utf8(seq).map_err(|_| {
+                Error::NoSequenceRecord("Failed converting seq to UTF-8.".to_string())
+            });
         } else {
             // Otherwise, look up the sequence in the transcript database.
             let seq_idx = *self

--- a/src/annotate/seqvars/snapshots/mehari__annotate__seqvars__csq__test__annotate_del_opa1_csqs@3-193311167-ATGT-T.snap
+++ b/src/annotate/seqvars/snapshots/mehari__annotate__seqvars__csq__test__annotate_del_opa1_csqs@3-193311167-ATGT-T.snap
@@ -7,6 +7,7 @@ expression: res
       alternative: T
   consequences:
     - start_lost
+    - conservative_inframe_deletion
   putative_impact: high
   gene_symbol: OPA1
   gene_id: "HGNC:8140"

--- a/src/annotate/seqvars/snapshots/mehari__annotate__seqvars__csq__test__annotate_del_opa1_csqs@3-193311170-TGGCG-G.snap
+++ b/src/annotate/seqvars/snapshots/mehari__annotate__seqvars__csq__test__annotate_del_opa1_csqs@3-193311170-TGGCG-G.snap
@@ -7,6 +7,7 @@ expression: res
       alternative: G
   consequences:
     - frameshift_variant
+    - frameshift_truncation
   putative_impact: high
   gene_symbol: OPA1
   gene_id: "HGNC:8140"

--- a/src/annotate/seqvars/snapshots/mehari__annotate__seqvars__csq__test__annotate_del_opa1_csqs@3-193409913-ATAA-A.snap
+++ b/src/annotate/seqvars/snapshots/mehari__annotate__seqvars__csq__test__annotate_del_opa1_csqs@3-193409913-ATAA-A.snap
@@ -8,6 +8,7 @@ expression: res
   consequences:
     - stop_lost
     - feature_elongation
+    - conservative_inframe_deletion
   putative_impact: high
   gene_symbol: OPA1
   gene_id: "HGNC:8140"

--- a/src/db/check/mod.rs
+++ b/src/db/check/mod.rs
@@ -154,8 +154,8 @@ fn load_cdot_files(paths: &[PathBuf]) -> Result<IdCollection> {
 #[derive(Debug, Serialize, Deserialize)]
 struct HgncEntry {
     hgnc_id: String,
-    location: String,
-    location_sortable: String,
+    location: Option<String>,
+    location_sortable: Option<String>,
     locus_group: String,
     locus_type: String,
     name: String,

--- a/tests/data/annotate/seqvars/vep.disagreement-cases.expected.vcf
+++ b/tests/data/annotate/seqvars/vep.disagreement-cases.expected.vcf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e571c7c86d42c00a6af1a313279ea5f33c6a7531449f04f03a278fc929f001be
-size 17967
+oid sha256:00947bc5c7d39bbb6e4c1187f5bbeab5b5f5c8b3bd37909dee6a5e9440675367
+size 18657


### PR DESCRIPTION
## Changes
- be specific whether a `frameshift_variant` shortens or lengthens by annotating SO terms `frameshift_truncation` and `frameshift_elongation`
- handle cases where a (cDNA) frameshift effectively resolves to a missense on protein level _(this requires re-obtaining the reference sequence and integrating the variant via the AltBuilder, as hgvs-rs does not provide all necessary information for this use-case)_
- define `inframe_{insertion,deletion}` in terms of CDS, as suggested in their SO term definition
- fix some `{5,3}_prime_UTR_variant` cases
- in the case of a delIns (on protein level):
  - always annotate `protein_altering_variant` (unless it resolves to a missense)
  - evaluate length change (between reference and alternative) to differentiate between `inframe_deletion`, `inframe_insertion` and `missense_variant` (previously would always report `deletion`)

## New consequence terms
 - [`frameshift_truncation`](http://www.sequenceontology.org/browser/current_release/term/SO:0001910)
 - [`frameshift_elongation`](http://www.sequenceontology.org/browser/current_release/term/SO:0001909)
 - [`protein_altering_variant`](http://www.sequenceontology.org/browser/current_release/term/SO:0001818)

## TODO
- [x] update test cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependencies and API specification to enhance overall stability.
  
- **New Features**
  - Expanded variant consequence reporting with additional annotations for frameshift events and protein-altering changes.
  - Enhanced variant analysis with improved normalization and detailed protein evaluations.
  
- **Bug Fixes**
  - Improved sequence data retrieval with clearer, more robust error messaging.
  - Refined handling of optional location information for more consistent outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->