### PR TITLE
fix: report `transcript_ablation` for deletions starting pre start and ending post stop

### DIFF
--- a/src/annotate/seqvars/csq.rs
+++ b/src/annotate/seqvars/csq.rs
@@ -970,6 +970,13 @@ impl ConsequencePredictor {
                 consequences |= Consequence::StopLost;
             }
 
+            if starts_left_of_start
+                && ends_right_of_stop
+                && matches!(edit, NaEdit::DelNum { .. } | NaEdit::DelRef { .. })
+            {
+                consequences |= Consequence::TranscriptAblation;
+            }
+
             // Detect variants affecting the 5'/3' UTRs.
             if starts_left_of_start && start_base < 0 {
                 if is_intronic {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced variant consequence analysis to now detect transcript ablation in cases where deletions span from before the start codon to beyond the stop codon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->