### PR TITLE
feat: Miscellaneous consequence prediction fixes

### DIFF
--- a/src/annotate/seqvars/ann.rs
+++ b/src/annotate/seqvars/ann.rs
@@ -105,7 +105,6 @@ pub enum Consequence {
     /// SO:transcript_amplification, VEP:transcript_amplification
     TranscriptAmplification,
 
-    // Currently never written out (because hgvs::parser::ProteinEdit::Ext not produced)
     /// "A sequence variant that causes the extension of a genomic feature, with regard to the reference sequence."
     /// SO:feature_elongation, VEP:feature_elongation
     FeatureElongation,

--- a/src/annotate/seqvars/csq.rs
+++ b/src/annotate/seqvars/csq.rs
@@ -1160,29 +1160,16 @@ impl ConsequencePredictor {
                         }
                         ProteinEdit::DelIns { alternative } => {
                             consequences |= Consequence::ProteinAlteringVariant;
-                            match alternative
+                            if alternative
                                 .len()
                                 .cmp(&(loc.start.number.abs_diff(loc.end.number) as usize + 1))
+                                == Ordering::Equal
                             {
-                                Ordering::Less if conservative => {
-                                    consequences |= Consequence::ConservativeInframeDeletion;
-                                }
-                                Ordering::Less => {
-                                    consequences |= Consequence::DisruptiveInframeDeletion;
-                                }
-                                Ordering::Equal => {
-                                    // When the delins does not change the CDS length,
-                                    // it is a missense variant, not an inframe deletion
-                                    // cf https://github.com/Ensembl/ensembl-vep/issues/1388
-                                    consequences |= Consequence::MissenseVariant;
-                                    consequences &= !Consequence::ProteinAlteringVariant;
-                                }
-                                Ordering::Greater if conservative => {
-                                    consequences |= Consequence::ConservativeInframeInsertion;
-                                }
-                                Ordering::Greater => {
-                                    consequences |= Consequence::DisruptiveInframeInsertion;
-                                }
+                                // When the delins does not change the CDS length,
+                                // it is a missense variant, not an inframe deletion
+                                // cf https://github.com/Ensembl/ensembl-vep/issues/1388
+                                consequences |= Consequence::MissenseVariant;
+                                consequences &= !Consequence::ProteinAlteringVariant;
                             }
 
                             if (is_stop(&loc.start.aa) || is_stop(&loc.end.aa))


### PR DESCRIPTION
- do not report `*_inframe_{deletion, insertion}` on var_p level, as these are defined on the var_c level
- fix definition of `is_intronic` in `analyse_cds_variant`
