### PR TITLE
fix: TSV output + --keep-intergenic

### DIFF
--- a/src/annotate/seqvars/csq.rs
+++ b/src/annotate/seqvars/csq.rs
@@ -390,6 +390,10 @@ impl ConsequencePredictor {
                 == TranscriptBiotype::Coding
                 && tx.start_codon.is_none()
             {
+                tracing::debug!(
+                    "Skipping transcript {} because it is coding but has no CDS",
+                    &tx_record.tx_ac
+                );
                 return Ok(None);
             }
             tx


### PR DESCRIPTION
Because of the way TSV output groups annotations by gene / hgnc_id and performs hgnc_id lookup, it would skip writing intergenic variants. This PR constitutes a band-aid to work around this behaviour.
(Ideally, TSV output should be purged and done via e.g. vembrane table or bcftools format etc.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of intergenic variants by allowing them to be processed with a placeholder record instead of being skipped.
* **Bug Fixes**
  * Enhanced logging and warnings for missing gene records, providing clearer feedback when gene information is unavailable.
* **Chores**
  * Added debug logging for skipped transcripts lacking coding sequence, aiding in troubleshooting and transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->