### PR TITLE
fix: do not require reference in `server run`

### DIFF
--- a/src/server/run/mod.rs
+++ b/src/server/run/mod.rs
@@ -342,7 +342,7 @@ pub async fn run(args_common: &crate::common::Args, args: &Args) -> Result<(), a
         }
     }
 
-    let mut all_releases = HashSet::new();
+    let mut all_releases: HashSet<GenomeRelease> = HashSet::new();
     all_releases.extend(transcript_paths.keys());
     all_releases.extend(frequency_paths.keys());
     all_releases.extend(clinvar_paths.keys());
@@ -440,6 +440,11 @@ pub async fn run(args_common: &crate::common::Args, args: &Args) -> Result<(), a
     }
     let data = actix_web::web::Data::new(data);
     tracing::info!("... done loading data {:?}", before_loading.elapsed());
+
+    if enabled_sources.is_empty() {
+        tracing::error!("No data sources loaded. Exiting.");
+        return Err(anyhow::anyhow!("No data sources loaded."));
+    }
 
     tracing::info!("Loaded the following sources: {:?}", &enabled_sources);
 


### PR DESCRIPTION
<!--

NOTE
NOTE In most cases, you should create an issue first, and only then
NOTE a pull request.  Please see the contribution guidelines for
NOTE further information.  In particular related to conventional
NOTE commit messages.
NOTE

The title should have the following format:

  <type>: description (#<issue>)

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unified per-release data loading for transcripts, population frequencies, and ClinVar, with clearer per-release progress messages.
- Improvements
  - More robust startup: server now requires at least one data source to load and exits early otherwise.
  - Always attempts predictor setup when transcript data is available; improved handling when reference data is missing (warns and proceeds when feasible).
  - More granular success and warning logs for each release and data source.
- Bug Fixes
  - Prevents starting in an unusable state when no data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->