### PR TITLE
fix: strucvars TSV mixing up "ad" and "gq"

### DIFF
--- a/src/annotate/strucvars/mod.rs
+++ b/src/annotate/strucvars/mod.rs
@@ -619,7 +619,7 @@ impl GenotypeCalls {
                     result.push(',');
                 }
                 prev = true;
-                result.push_str(&format!("\"\"\"ad\"\"\":{}", gq));
+                result.push_str(&format!("\"\"\"gq\"\"\":{}", gq));
             }
 
             if let Some(pec) = &entry.pec {

--- a/tests/data/annotate/strucvars/example-grch38.tsv
+++ b/tests/data/annotate/strucvars/example-grch38.tsv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:445b74da473e974690478779f67c37e7b4d08a70cfecdc5147cb987e55bf7bfd
+oid sha256:cbf7645a5020258d32cc27ca4cc1627719551ea2eed84b923141c341d0631bff
 size 1250

--- a/tests/data/annotate/strucvars/maelstrom/delly2-min-with-maelstrom.tsv
+++ b/tests/data/annotate/strucvars/maelstrom/delly2-min-with-maelstrom.tsv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7892b992a6b5dd1279bcf1cfd80bbfa4339e18fecc0731b990dcfcfa741c10d6
+oid sha256:ab949cc9b95f7a28f36d64768ffd76fc0410579c440480a0ebb7e9dc35aa11b4
 size 491


### PR DESCRIPTION
When writing strucvars TSV output, the genotype quality (gq) was erroneously written to the allele depth (ad) field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the per-genotype field label for genotype quality in exported outputs. The GQ value is now labeled as "gq" (was incorrectly labeled as "ad"), ensuring accurate headers and consistent formatting across TSV/JSON-like outputs. This improves data clarity and interoperability with downstream tools. No changes to behavior, data values, or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->